### PR TITLE
fix: handle undefined schedule_map in JavaScript

### DIFF
--- a/hospital-booking/flask_app/app/templates/settings/availability/index.html
+++ b/hospital-booking/flask_app/app/templates/settings/availability/index.html
@@ -1881,7 +1881,7 @@ function toggleSelectAllProviders() {
         form.action = form.dataset.createAction;
 
         // Auto-fill เวลาจาก template schedule
-        const templateSchedule = {{ schedule_map | tojson | safe }};
+        const templateSchedule = {{ (schedule_map if schedule_map is defined else {}) | tojson | safe }};
 
         // หาวันแรกที่มีตารางเวลา (ลองหาวันจันทร์ก่อน, ถ้าไม่มีก็หาวันอื่น)
         let firstSlot = null;


### PR DESCRIPTION
- เพิ่ม default value {} เมื่อ schedule_map ไม่ได้กำหนด
- แก้ไข TypeError: Object of type Undefined is not JSON serializable
- ใช้ Jinja2 conditional: (schedule_map if schedule_map is defined else {})