### PR TITLE
feat: add profile edit and password change with OTP verification

### DIFF
--- a/hospital-booking/flask_app/app/auth.py
+++ b/hospital-booking/flask_app/app/auth.py
@@ -1,12 +1,15 @@
 # flask_app/app/auth.py - ระบบ Authentication
 
-from flask import Blueprint, render_template, request, redirect, url_for, flash, session, g
+from flask import Blueprint, render_template, request, redirect, url_for, flash, session, g, jsonify
 from werkzeug.security import check_password_hash
 from sqlalchemy import text
 from shared_db.models import User, Hospital
-from shared_db.database import SessionLocal, get_db_session 
+from shared_db.database import SessionLocal, get_db_session
 from .core.tenant_manager import TenantManager
 from .utils.url_helper import get_dashboard_url
+from .services.otp_service import otp_service
+from .services.email_service import queue_otp_email
+import re
 
 auth_bp = Blueprint('auth', __name__, url_prefix='/auth')
 
@@ -61,17 +64,234 @@ def logout():
 @auth_bp.route('/profile')
 def profile():
     """หน้าโปรไฟล์ผู้ใช้"""
-    
+
     if 'user_id' not in session:
         flash('กรุณาเข้าสู่ระบบ', 'error')
         return redirect(url_for('auth.login'))
-    
+
     db = get_db_session()
     try:
         user = db.query(User).filter_by(id=session['user_id']).first()
         hospital = db.query(Hospital).filter_by(id=user.hospital_id).first()
-        
+
         return render_template('auth/profile.html', user=user, hospital=hospital)
+    finally:
+        db.close()
+
+@auth_bp.route('/edit-profile', methods=['POST'])
+def edit_profile():
+    """แก้ไขข้อมูลโปรไฟล์"""
+
+    if 'user_id' not in session:
+        return jsonify({'success': False, 'message': 'กรุณาเข้าสู่ระบบ'}), 401
+
+    db = get_db_session()
+    try:
+        user = db.query(User).filter_by(id=session['user_id']).first()
+        if not user:
+            return jsonify({'success': False, 'message': 'ไม่พบข้อมูลผู้ใช้'}), 404
+
+        # รับข้อมูลจากฟอร์ม
+        new_name = request.form.get('name', '').strip()
+        new_email = request.form.get('email', '').strip()
+        new_phone = request.form.get('phone_number', '').strip()
+
+        # ตรวจสอบว่ามีการเปลี่ยนแปลงหรือไม่
+        email_changed = new_email and new_email != user.email
+        phone_changed = new_phone and new_phone != user.phone_number
+
+        # Validate email format if changed
+        if email_changed:
+            email_pattern = re.compile(r'^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$')
+            if not email_pattern.match(new_email):
+                return jsonify({'success': False, 'message': 'รูปแบบอีเมลไม่ถูกต้อง'}), 400
+
+            # ตรวจสอบว่าอีเมลซ้ำหรือไม่
+            existing_user = db.query(User).filter_by(email=new_email).first()
+            if existing_user and existing_user.id != user.id:
+                return jsonify({'success': False, 'message': 'อีเมลนี้ถูกใช้งานแล้ว'}), 400
+
+        # ถ้ามีการเปลี่ยน email หรือ phone ต้องส่ง OTP
+        if email_changed or phone_changed:
+            # เก็บข้อมูลใหม่ไว้ใน session ชั่วคราว
+            session['pending_profile_update'] = {
+                'name': new_name,
+                'email': new_email if email_changed else user.email,
+                'phone_number': new_phone if phone_changed else user.phone_number,
+                'email_changed': email_changed,
+                'phone_changed': phone_changed
+            }
+
+            # ส่ง OTP ไปยังอีเมลใหม่ (ถ้ามีการเปลี่ยน) หรืออีเมลเดิม
+            target_email = new_email if email_changed else user.email
+            otp = otp_service.generate_otp(target_email, expiration=300)
+
+            try:
+                queue_otp_email(target_email, otp)
+                return jsonify({
+                    'success': True,
+                    'requires_otp': True,
+                    'message': f'ส่งรหัส OTP ไปยัง {target_email} แล้ว',
+                    'target_email': target_email
+                })
+            except Exception as e:
+                return jsonify({'success': False, 'message': f'ไม่สามารถส่ง OTP ได้: {str(e)}'}), 500
+
+        # ถ้าแก้แค่ชื่อ ไม่ต้อง OTP
+        if new_name:
+            user.name = new_name
+            db.commit()
+            return jsonify({'success': True, 'requires_otp': False, 'message': 'บันทึกข้อมูลเรียบร้อย'})
+
+        return jsonify({'success': False, 'message': 'ไม่มีข้อมูลที่ต้องแก้ไข'}), 400
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'success': False, 'message': f'เกิดข้อผิดพลาด: {str(e)}'}), 500
+    finally:
+        db.close()
+
+@auth_bp.route('/verify-profile-otp', methods=['POST'])
+def verify_profile_otp():
+    """ยืนยัน OTP สำหรับการแก้ไขโปรไฟล์"""
+
+    if 'user_id' not in session:
+        return jsonify({'success': False, 'message': 'กรุณาเข้าสู่ระบบ'}), 401
+
+    if 'pending_profile_update' not in session:
+        return jsonify({'success': False, 'message': 'ไม่พบข้อมูลการแก้ไขที่รอดำเนินการ'}), 400
+
+    otp_input = request.form.get('otp', '').strip()
+    if not otp_input:
+        return jsonify({'success': False, 'message': 'กรุณากรอกรหัส OTP'}), 400
+
+    db = get_db_session()
+    try:
+        user = db.query(User).filter_by(id=session['user_id']).first()
+        if not user:
+            return jsonify({'success': False, 'message': 'ไม่พบข้อมูลผู้ใช้'}), 404
+
+        pending_data = session['pending_profile_update']
+        target_email = pending_data['email']
+
+        # ตรวจสอบ OTP
+        success, message = otp_service.verify_otp(target_email, otp_input)
+
+        if success:
+            # อัพเดทข้อมูล
+            user.name = pending_data['name']
+            user.email = pending_data['email']
+            user.phone_number = pending_data['phone_number']
+
+            db.commit()
+
+            # ลบข้อมูลชั่วคราว
+            session.pop('pending_profile_update', None)
+
+            return jsonify({'success': True, 'message': 'บันทึกข้อมูลเรียบร้อย'})
+        else:
+            return jsonify({'success': False, 'message': message}), 400
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'success': False, 'message': f'เกิดข้อผิดพลาด: {str(e)}'}), 500
+    finally:
+        db.close()
+
+@auth_bp.route('/change-password', methods=['POST'])
+def change_password():
+    """เปลี่ยนรหัสผ่าน"""
+
+    if 'user_id' not in session:
+        return jsonify({'success': False, 'message': 'กรุณาเข้าสู่ระบบ'}), 401
+
+    db = get_db_session()
+    try:
+        user = db.query(User).filter_by(id=session['user_id']).first()
+        if not user:
+            return jsonify({'success': False, 'message': 'ไม่พบข้อมูลผู้ใช้'}), 404
+
+        current_password = request.form.get('current_password', '').strip()
+        new_password = request.form.get('new_password', '').strip()
+        confirm_password = request.form.get('confirm_password', '').strip()
+
+        # ตรวจสอบข้อมูล
+        if not current_password or not new_password or not confirm_password:
+            return jsonify({'success': False, 'message': 'กรุณากรอกข้อมูลให้ครบถ้วน'}), 400
+
+        # ตรวจสอบรหัสผ่านปัจจุบัน
+        if not user.check_password(current_password):
+            return jsonify({'success': False, 'message': 'รหัสผ่านปัจจุบันไม่ถูกต้อง'}), 400
+
+        # ตรวจสอบรหัสผ่านใหม่ตรงกันหรือไม่
+        if new_password != confirm_password:
+            return jsonify({'success': False, 'message': 'รหัสผ่านใหม่ไม่ตรงกัน'}), 400
+
+        # ตรวจสอบความแข็งแรงของรหัสผ่าน
+        if len(new_password) < 8:
+            return jsonify({'success': False, 'message': 'รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร'}), 400
+
+        # เก็บข้อมูลรหัสผ่านใหม่ไว้ใน session
+        session['pending_password_change'] = new_password
+
+        # ส่ง OTP ไปยังอีเมล
+        otp = otp_service.generate_otp(user.email, expiration=300)
+
+        try:
+            queue_otp_email(user.email, otp)
+            return jsonify({
+                'success': True,
+                'requires_otp': True,
+                'message': f'ส่งรหัส OTP ไปยัง {user.email} แล้ว'
+            })
+        except Exception as e:
+            return jsonify({'success': False, 'message': f'ไม่สามารถส่ง OTP ได้: {str(e)}'}), 500
+
+    except Exception as e:
+        return jsonify({'success': False, 'message': f'เกิดข้อผิดพลาด: {str(e)}'}), 500
+    finally:
+        db.close()
+
+@auth_bp.route('/verify-password-otp', methods=['POST'])
+def verify_password_otp():
+    """ยืนยัน OTP สำหรับการเปลี่ยนรหัสผ่าน"""
+
+    if 'user_id' not in session:
+        return jsonify({'success': False, 'message': 'กรุณาเข้าสู่ระบบ'}), 401
+
+    if 'pending_password_change' not in session:
+        return jsonify({'success': False, 'message': 'ไม่พบข้อมูลการเปลี่ยนรหัสผ่านที่รอดำเนินการ'}), 400
+
+    otp_input = request.form.get('otp', '').strip()
+    if not otp_input:
+        return jsonify({'success': False, 'message': 'กรุณากรอกรหัส OTP'}), 400
+
+    db = get_db_session()
+    try:
+        user = db.query(User).filter_by(id=session['user_id']).first()
+        if not user:
+            return jsonify({'success': False, 'message': 'ไม่พบข้อมูลผู้ใช้'}), 404
+
+        # ตรวจสอบ OTP
+        success, message = otp_service.verify_otp(user.email, otp_input)
+
+        if success:
+            # เปลี่ยนรหัสผ่าน
+            new_password = session['pending_password_change']
+            user.set_password(new_password)
+
+            db.commit()
+
+            # ลบข้อมูลชั่วคราว
+            session.pop('pending_password_change', None)
+
+            return jsonify({'success': True, 'message': 'เปลี่ยนรหัสผ่านเรียบร้อย'})
+        else:
+            return jsonify({'success': False, 'message': message}), 400
+
+    except Exception as e:
+        db.rollback()
+        return jsonify({'success': False, 'message': f'เกิดข้อผิดพลาด: {str(e)}'}), 500
     finally:
         db.close()
 

--- a/hospital-booking/flask_app/app/templates/auth/profile.html
+++ b/hospital-booking/flask_app/app/templates/auth/profile.html
@@ -89,10 +89,10 @@
 
                 <!-- Action Buttons -->
                 <div class="mt-8 flex space-x-4">
-                    <button class="bg-purple-600 text-white px-4 py-2 rounded-lg hover:bg-purple-700">
+                    <button onclick="openEditProfileModal()" class="bg-purple-600 text-white px-4 py-2 rounded-lg hover:bg-purple-700">
                         แก้ไขข้อมูล
                     </button>
-                    <button class="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-300">
+                    <button onclick="openChangePasswordModal()" class="bg-gray-200 text-gray-700 px-4 py-2 rounded-lg hover:bg-gray-300">
                         เปลี่ยนรหัสผ่าน
                     </button>
                     <a href="/dashboard?subdomain={{ hospital.subdomain }}" class="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700">
@@ -113,5 +113,207 @@
         </div>
     </div>
 
+    <!-- Edit Profile Modal -->
+    <div id="editProfileModal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3">
+                <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">แก้ไขข้อมูลส่วนตัว</h3>
+                <form id="editProfileForm" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">ชื่อ</label>
+                        <input type="text" name="name" value="{{ user.name }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">อีเมล</label>
+                        <input type="email" name="email" value="{{ user.email }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                        <p class="mt-1 text-xs text-amber-600">⚠️ การเปลี่ยนอีเมลต้องยืนยันด้วย OTP</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">เบอร์โทรศัพท์</label>
+                        <input type="tel" name="phone_number" value="{{ user.phone_number or '' }}" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                        <p class="mt-1 text-xs text-amber-600">⚠️ การเปลี่ยนเบอร์โทรต้องยืนยันด้วย OTP</p>
+                    </div>
+                    <div class="flex justify-end space-x-2 pt-4">
+                        <button type="button" onclick="closeEditProfileModal()" class="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400">ยกเลิก</button>
+                        <button type="submit" class="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700">บันทึก</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- Change Password Modal -->
+    <div id="changePasswordModal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3">
+                <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">เปลี่ยนรหัสผ่าน</h3>
+                <form id="changePasswordForm" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">รหัสผ่านปัจจุบัน</label>
+                        <input type="password" name="current_password" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">รหัสผ่านใหม่</label>
+                        <input type="password" name="new_password" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                        <p class="mt-1 text-xs text-gray-500">รหัสผ่านต้องมีอย่างน้อย 8 ตัวอักษร</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">ยืนยันรหัสผ่านใหม่</label>
+                        <input type="password" name="confirm_password" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500">
+                    </div>
+                    <p class="text-xs text-amber-600">⚠️ การเปลี่ยนรหัสผ่านต้องยืนยันด้วย OTP ที่ส่งไปยังอีเมลของคุณ</p>
+                    <div class="flex justify-end space-x-2 pt-4">
+                        <button type="button" onclick="closeChangePasswordModal()" class="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400">ยกเลิก</button>
+                        <button type="submit" class="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700">เปลี่ยนรหัสผ่าน</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+    <!-- OTP Verification Modal -->
+    <div id="otpModal" class="hidden fixed inset-0 bg-gray-600 bg-opacity-50 overflow-y-auto h-full w-full z-50">
+        <div class="relative top-20 mx-auto p-5 border w-96 shadow-lg rounded-md bg-white">
+            <div class="mt-3">
+                <h3 class="text-lg font-medium leading-6 text-gray-900 mb-4">ยืนยัน OTP</h3>
+                <p class="text-sm text-gray-600 mb-4" id="otpMessage">กรุณากรอกรหัส OTP ที่ส่งไปยังอีเมลของคุณ</p>
+                <form id="otpForm" class="space-y-4">
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">รหัส OTP (6 หลัก)</label>
+                        <input type="text" name="otp" maxlength="6" pattern="[0-9]{6}" required
+                               class="mt-1 block w-full text-center text-2xl tracking-widest rounded-md border-gray-300 shadow-sm focus:border-purple-500 focus:ring-purple-500"
+                               placeholder="000000">
+                    </div>
+                    <input type="hidden" name="otp_type" id="otpType">
+                    <div class="flex justify-end space-x-2 pt-4">
+                        <button type="button" onclick="closeOtpModal()" class="px-4 py-2 bg-gray-300 text-gray-700 rounded-md hover:bg-gray-400">ยกเลิก</button>
+                        <button type="submit" class="px-4 py-2 bg-purple-600 text-white rounded-md hover:bg-purple-700">ยืนยัน</button>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    // Modal Functions
+    function openEditProfileModal() {
+        document.getElementById('editProfileModal').classList.remove('hidden');
+    }
+
+    function closeEditProfileModal() {
+        document.getElementById('editProfileModal').classList.add('hidden');
+    }
+
+    function openChangePasswordModal() {
+        document.getElementById('changePasswordModal').classList.remove('hidden');
+    }
+
+    function closeChangePasswordModal() {
+        document.getElementById('changePasswordModal').classList.add('hidden');
+        document.getElementById('changePasswordForm').reset();
+    }
+
+    function openOtpModal(message, type) {
+        document.getElementById('otpMessage').textContent = message;
+        document.getElementById('otpType').value = type;
+        document.getElementById('otpModal').classList.remove('hidden');
+    }
+
+    function closeOtpModal() {
+        document.getElementById('otpModal').classList.add('hidden');
+        document.getElementById('otpForm').reset();
+    }
+
+    // Edit Profile Form Submission
+    document.getElementById('editProfileForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(e.target);
+
+        try {
+            const response = await fetch('/auth/edit-profile', {
+                method: 'POST',
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (data.success) {
+                if (data.requires_otp) {
+                    closeEditProfileModal();
+                    openOtpModal(data.message, 'profile');
+                } else {
+                    alert(data.message);
+                    location.reload();
+                }
+            } else {
+                alert(data.message);
+            }
+        } catch (error) {
+            alert('เกิดข้อผิดพลาด: ' + error.message);
+        }
+    });
+
+    // Change Password Form Submission
+    document.getElementById('changePasswordForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(e.target);
+
+        try {
+            const response = await fetch('/auth/change-password', {
+                method: 'POST',
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (data.success) {
+                closeChangePasswordModal();
+                openOtpModal(data.message, 'password');
+            } else {
+                alert(data.message);
+            }
+        } catch (error) {
+            alert('เกิดข้อผิดพลาด: ' + error.message);
+        }
+    });
+
+    // OTP Form Submission
+    document.getElementById('otpForm').addEventListener('submit', async (e) => {
+        e.preventDefault();
+
+        const formData = new FormData(e.target);
+        const otpType = formData.get('otp_type');
+
+        const endpoint = otpType === 'profile' ? '/auth/verify-profile-otp' : '/auth/verify-password-otp';
+
+        try {
+            const response = await fetch(endpoint, {
+                method: 'POST',
+                body: formData
+            });
+
+            const data = await response.json();
+
+            if (data.success) {
+                alert(data.message);
+                location.reload();
+            } else {
+                alert(data.message);
+            }
+        } catch (error) {
+            alert('เกิดข้อผิดพลาด: ' + error.message);
+        }
+    });
+
+    // Auto-format OTP input (only allow numbers)
+    document.querySelector('input[name="otp"]').addEventListener('input', function(e) {
+        this.value = this.value.replace(/[^0-9]/g, '');
+    });
+</script>
 {% endblock %}
 


### PR DESCRIPTION
Implemented secure profile editing and password change functionality with OTP verification:

Profile Edit Features:
- Edit name without OTP (low-impact change)
- Edit email with OTP verification sent to new email
- Edit phone number with OTP verification
- Email format validation and duplicate checking
- Subdomain is intentionally NOT editable (high-impact field)

Password Change Features:
- Current password verification required
- New password strength validation (minimum 8 characters)
- OTP verification sent to user's email
- Password confirmation matching

OTP Security:
- Uses pyotp for generating 6-digit time-based OTP
- 5-minute expiration window
- Maximum 3 verification attempts
- OTPs sent via email using existing queue_otp_email service

UI/UX Improvements:
- Added modal dialogs for edit profile and change password
- Clear warnings for fields requiring OTP verification
- AJAX form submissions with proper error handling
- Responsive design with Tailwind CSS

Technical Implementation:
- Added routes: /auth/edit-profile, /auth/verify-profile-otp
- Added routes: /auth/change-password, /auth/verify-password-otp
- Session-based temporary storage for pending changes
- Integrated with existing OTP and email services