### PR TITLE
feat(messaging): LINE/Telegram/PWA channels, deep-link entry, analyti…

### DIFF
--- a/hospital-booking/flask_app/app/__init__.py
+++ b/hospital-booking/flask_app/app/__init__.py
@@ -328,6 +328,15 @@ def create_app() -> Flask:
     from .analytics_routes import analytics_bp
     app.register_blueprint(analytics_bp)
 
+    # 9. ลงทะเบียน Messaging Webhooks (external providers sign their own payloads)
+    from .webhook_routes import webhook_bp
+    csrf.exempt(webhook_bp)
+    app.register_blueprint(webhook_bp)
+
+    # 10. ลงทะเบียน PWA manifest/service worker (root scope)
+    from .pwa_routes import pwa_bp
+    app.register_blueprint(pwa_bp)
+
     # Exempt the specific view from CSRF protection
     # csrf.exempt('booking.get_availability')
 

--- a/hospital-booking/flask_app/app/analytics_routes.py
+++ b/hospital-booking/flask_app/app/analytics_routes.py
@@ -44,6 +44,7 @@ def index():
 
     queue = analytics_service.queue_summary(g.db, date_from, date_to)
     messaging = analytics_service.message_cost_summary(g.db, date_from, date_to)
+    line_quota = analytics_service.line_message_quota(g.db)  # best-effort; None if LINE off/down
 
     return render_template(
         'analytics/index.html',
@@ -51,4 +52,5 @@ def index():
         date_to=date_to,
         queue=queue,
         messaging=messaging,
+        line_quota=line_quota,
     )

--- a/hospital-booking/flask_app/app/pwa_routes.py
+++ b/hospital-booking/flask_app/app/pwa_routes.py
@@ -1,0 +1,79 @@
+"""Tenant-aware PWA manifest and service worker endpoints."""
+
+from __future__ import annotations
+
+from flask import Blueprint, Response, g, jsonify
+
+from shared_db import models
+
+pwa_bp = Blueprint("pwa", __name__)
+
+
+def _messaging_config():
+    # messaging_config is tenant-only; without a bound tenant g.db is on public and the
+    # query would 500. Callers treat None as "not configured".
+    if not getattr(g, "tenant", None):
+        return None
+    return (g.db.query(models.MessagingConfig)
+            .order_by(models.MessagingConfig.id.asc()).first())
+
+
+@pwa_bp.route("/manifest.json")
+def manifest():
+    hospital_name = getattr(getattr(g, "hospital", None), "name", None) or "NudDee"
+    return jsonify({
+        "name": f"{hospital_name} Queue",
+        "short_name": hospital_name[:12] or "NudDee",
+        "start_url": "/",
+        "scope": "/",
+        "display": "standalone",
+        "background_color": "#f8fafc",
+        "theme_color": "#6d28d9",
+        "lang": "th",
+    })
+
+
+@pwa_bp.route("/pwa/config")
+def pwa_config():
+    config = _messaging_config()
+    public_key = getattr(config, "pwa_vapid_public_key", None)
+    active = bool(config and config.pwa_status == "active" and public_key)
+    return jsonify({
+        "active": active,
+        "vapidPublicKey": public_key if active else None,
+    })
+
+
+@pwa_bp.route("/service-worker.js")
+def service_worker():
+    body = """
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("push", (event) => {
+  let payload = { title: "NudDee", body: "มีการแจ้งเตือนใหม่" };
+  if (event.data) {
+    try {
+      payload = Object.assign(payload, event.data.json());
+    } catch (_) {
+      payload.body = event.data.text();
+    }
+  }
+  event.waitUntil(self.registration.showNotification(payload.title || "NudDee", {
+    body: payload.body || "",
+    data: { url: payload.url || "/" },
+  }));
+});
+
+self.addEventListener("notificationclick", (event) => {
+  event.notification.close();
+  const targetUrl = event.notification.data && event.notification.data.url || "/";
+  event.waitUntil(self.clients.openWindow(targetUrl));
+});
+""".strip()
+    return Response(body, mimetype="application/javascript")

--- a/hospital-booking/flask_app/app/queue_routes.py
+++ b/hospital-booking/flask_app/app/queue_routes.py
@@ -6,13 +6,19 @@ Flask-first: business logic อยู่ที่ services/queue_service.py — 
 g.db ถูกตั้ง search_path ไป tenant schema แล้วโดย before_request middleware
 """
 
-from flask import Blueprint, render_template, request, flash, redirect, abort, g
+import os
+
+import redis as _redis_lib
+from flask import Blueprint, render_template, request, flash, redirect, abort, g, jsonify
+from itsdangerous import BadSignature, URLSafeSerializer
 
 from .auth import login_required, get_current_user
 from .core.tenant_manager import TenantManager
 from .utils.url_helper import build_url_with_context
 from .services import grace_service as gs
 from .services import identity_service as ids
+from .services import messaging_identity as mi
+from .services import messaging_links
 from .services import priority_service as ps
 from .services import queue_notifications as qn
 from .services import queue_service as qs
@@ -40,11 +46,98 @@ _ACTION_TO_STATUS = {
 }
 
 
+def _ticket_serializer():
+    secret = os.environ.get('SECRET_KEY', 'a-dev-secret-key')
+    return URLSafeSerializer(secret, salt='queue-ticket')
+
+
+def make_ticket_token(entry_id, tenant):
+    """Unguessable, tenant-bound handle for a queue entry's ticket URL.
+
+    Replaces the enumerable numeric entry_id so nobody can guess a ticket URL to
+    view someone's queue status or (worse) bind their own push subscription to
+    another patient's notifications via the pwa-subscription POST.
+    """
+    # ponytail: no expiry — the token only de-enumerates; the entry's own
+    # status/date bounds its usefulness and a leaked token exposes one entry.
+    return _ticket_serializer().dumps([str(tenant or ''), int(entry_id)])
+
+
+def read_ticket_token(token, tenant):
+    """Return the entry_id from a valid token for this tenant, else None."""
+    try:
+        scope, entry_id = _ticket_serializer().loads(token)
+    except (BadSignature, ValueError, TypeError):
+        return None
+    if scope != str(tenant or ''):      # reject tokens minted for another tenant
+        return None
+    return int(entry_id)
+
+
+_redis_client = None
+
+
+def _get_redis():
+    global _redis_client
+    if _redis_client is None:
+        _redis_client = _redis_lib.from_url(
+            os.environ.get('REDIS_URL', 'redis://localhost:6379/0'))
+    return _redis_client
+
+
+def _rate_limited(redis_client, key, limit, window):
+    """Fixed-window counter: True once `key` is hit more than `limit` times per `window` s."""
+    count = redis_client.incr(key)
+    if count == 1:
+        redis_client.expire(key, window)
+    return count > limit
+
+
+def _client_ip():
+    fwd = request.headers.get('X-Forwarded-For', '')
+    return fwd.split(',')[0].strip() or request.remote_addr or 'unknown'
+
+
+def _too_many_checkins(sp_id):
+    """Per-IP throttle for the public, no-auth check-in POST (anti walk-in spam).
+
+    ponytail: Redis fixed window, fail-OPEN if Redis is down — never block a real
+    patient on an infra hiccup. Per-IP is coarse: a clinic behind one NAT shares the
+    budget, so keep the default generous and tune CHECKIN_RATE_* (or add a
+    per-booking-reference / CAPTCHA check) if NAT collisions bite at a busy counter.
+    """
+    limit = int(os.environ.get('CHECKIN_RATE_LIMIT', '20'))
+    window = int(os.environ.get('CHECKIN_RATE_WINDOW', '60'))
+    try:
+        return _rate_limited(_get_redis(), f'checkin_rl:{sp_id}:{_client_ip()}', limit, window)
+    except Exception:
+        return False
+
+
 def _service_point_or_404(sp_id):
     sp = g.db.query(models.ServicePoint).filter_by(id=sp_id).first()
     if sp is None:
         abort(404)
     return sp
+
+
+def _messaging_config():
+    # messaging_config lives only in tenant schemas; with no tenant bound g.db is on
+    # public, so querying it would 500 ("relation does not exist"). Callers treat
+    # None as "not configured" (e.g. /queue/enter opened without ?subdomain=).
+    if not getattr(g, 'tenant', None):
+        return None
+    return (g.db.query(models.MessagingConfig)
+            .order_by(models.MessagingConfig.id.asc()).first())
+
+
+def _render_checkin(sp):
+    return render_template(
+        'queue/checkin.html',
+        service_point=sp,
+        messaging_config=_messaging_config(),
+        channel_auth_url=build_url_with_context('queue.channel_auth'),
+    )
 
 
 def _deny_if_not_staff():
@@ -64,12 +157,60 @@ def _deny_if_not_staff():
 
 # ============================ Patient: check-in ============================
 
+@queue_bp.route('/channel-auth', methods=['POST'])
+def channel_auth():
+    """Link a verified Mini App/PWA identity to a server-resolved patient_ref."""
+    payload = request.get_json(silent=True) or {}
+    channel = (payload.get('channel') or '').strip().lower()
+    config = _messaging_config()
+
+    try:
+        if channel == 'line':
+            link = mi.link_line_identity(
+                g.db,
+                config=config,
+                id_token=payload.get('idToken'),
+                booking_reference=payload.get('booking_reference'),
+                patient_phone=payload.get('patient_phone'),
+            )
+        elif channel == 'telegram':
+            link = mi.link_telegram_identity(
+                g.db,
+                config=config,
+                init_data=payload.get('initData'),
+                booking_reference=payload.get('booking_reference'),
+                patient_phone=payload.get('patient_phone'),
+            )
+        elif channel == 'pwa':
+            link = mi.link_pwa_subscription(
+                g.db,
+                subscription=payload.get('subscription'),
+                booking_reference=payload.get('booking_reference'),
+                patient_phone=payload.get('patient_phone'),
+            )
+        else:
+            return jsonify({'linked': False, 'error': 'unsupported_channel'}), 400
+    except (mi.LineIdTokenError, mi.InitDataValidationError) as exc:
+        g.db.rollback()
+        return jsonify({'linked': False, 'error': str(exc)}), 403
+    except mi.ChannelIdentityError as exc:
+        g.db.rollback()
+        return jsonify({'linked': False, 'error': str(exc)}), 400
+
+    return jsonify({
+        'linked': True,
+        'channel': link.channel,
+    })
+
 @queue_bp.route('/checkin/<int:service_point_id>', methods=['GET', 'POST'])
 def checkin(service_point_id):
     """หน้าเช็คอิน (เปิดจาก QR ที่จุดบริการ — QR encode service_point_id)"""
     sp = _service_point_or_404(service_point_id)
 
     if request.method == 'POST':
+        if _too_many_checkins(sp.id):
+            flash('มีการเช็คอินบ่อยเกินไป กรุณารอสักครู่แล้วลองใหม่อีกครั้ง', 'error')
+            return _render_checkin(sp), 429
         name = (request.form.get('patient_name') or '').strip()
         phone = (request.form.get('patient_phone') or '').strip()
         booking_ref = (request.form.get('booking_reference') or '').strip()
@@ -80,33 +221,33 @@ def checkin(service_point_id):
                     .filter_by(booking_reference=booking_ref).first())
             if appt is None:
                 flash('ไม่พบรหัสการจองนี้ กรุณาตรวจสอบอีกครั้ง', 'error')
-                return render_template('queue/checkin.html', service_point=sp)
+                return _render_checkin(sp)
             appointment_id = appt.id
             patient_ref = ids.resolve_patient_ref(appointment=appt, phone=phone, required=False)
             if patient_ref is None:
                 flash('นัดนี้ยังไม่มีข้อมูลระบุตัวตนที่ใช้ผูกคิวได้ กรุณากรอกเบอร์โทรหรือแจ้งเจ้าหน้าที่', 'error')
-                return render_template('queue/checkin.html', service_point=sp)
+                return _render_checkin(sp)
         elif phone:
             patient_ref = ids.resolve_patient_ref(phone=phone, required=False)
             if patient_ref is None:
                 flash('เบอร์โทรศัพท์ไม่ถูกต้อง กรุณาตรวจสอบอีกครั้ง', 'error')
-                return render_template('queue/checkin.html', service_point=sp)
+                return _render_checkin(sp)
         else:
             flash('กรุณากรอกเบอร์โทรศัพท์ หรือรหัสการจอง', 'error')
-            return render_template('queue/checkin.html', service_point=sp)
+            return _render_checkin(sp)
 
         try:
             # check_in บังคับว่า นัดต้องตรงกับจุดบริการ/session ของจุดนี้ (กันสแกน QR ผิดจุด)
             result = qs.check_in(g.db, appointment_id, sp.id, patient_ref)
         except qs.ServicePointMismatch:
             flash('นัดนี้ไม่ได้อยู่ที่จุดบริการนี้ กรุณาตรวจสอบจุดบริการให้ถูกต้อง', 'error')
-            return render_template('queue/checkin.html', service_point=sp)
+            return _render_checkin(sp)
         except gs.NoShowError:
             flash('นัดนี้เลยช่วงผ่อนผันแล้ว กรุณาติดต่อเจ้าหน้าที่เพื่อตรวจสอบหรือจองใหม่', 'error')
-            return render_template('queue/checkin.html', service_point=sp)
+            return _render_checkin(sp)
         except ids.IdentityResolutionError:
             flash('ไม่สามารถระบุตัวตนสำหรับคิวนี้ได้ กรุณากรอกเบอร์โทรศัพท์หรือแจ้งเจ้าหน้าที่', 'error')
-            return render_template('queue/checkin.html', service_point=sp)
+            return _render_checkin(sp)
 
         if isinstance(result, qs.ArrivalCheckInResult):
             return redirect(build_url_with_context(
@@ -114,10 +255,30 @@ def checkin(service_point_id):
                 service_point_id=sp.id,
                 appointment_id=result.appointment_id,
             ))
-        qn.enqueue_checkin_confirm(g.tenant, result)
-        return redirect(build_url_with_context('queue.ticket', entry_id=result.id))
+        ticket_token = make_ticket_token(result.id, g.tenant)
+        qn.enqueue_checkin_confirm(g.tenant, result, url=build_url_with_context(
+            'queue.ticket', token=ticket_token, _external=True))
+        return redirect(build_url_with_context(
+            'queue.ticket', token=ticket_token, checkin_confirm=1))
 
-    return render_template('queue/checkin.html', service_point=sp)
+    return _render_checkin(sp)
+
+
+@queue_bp.route('/enter')
+def enter():
+    """Mini App / LIFF entry router (Phase 4.5/4.10 deep-link consumer).
+
+    Set this URL as the Telegram Mini App (BotFather /newapp) and the LINE LIFF
+    endpoint. queue_mini_app.js reads the deep-link param — Telegram `startapp=sp_<id>`
+    (arrives as `tgWebAppStartParam`) or LINE `service_point_id` / `checkin_url` — and
+    forwards to that service point's check-in page; with no param it falls back home.
+    LINE delivers its params inside liff.state, so the page needs the LIFF id to run
+    liff.init() and resolve them.
+    """
+    config = _messaging_config()
+    return render_template('queue/enter.html',
+                           default_url=build_url_with_context('main.index'),
+                           line_liff_id=getattr(config, 'line_liff_id', None) if config else None)
 
 
 @queue_bp.route('/arrival/<int:service_point_id>/<int:appointment_id>')
@@ -130,9 +291,12 @@ def arrival(service_point_id, appointment_id):
     return render_template('queue/arrival.html', appointment=appointment, service_point=sp)
 
 
-@queue_bp.route('/ticket/<int:entry_id>')
-def ticket(entry_id):
+@queue_bp.route('/ticket/<token>')
+def ticket(token):
     """บัตรคิว (pull-based ฟรี) — ผู้รับบริการเปิดดูเลขคิว + จำนวนคิวก่อนหน้า"""
+    entry_id = read_ticket_token(token, g.tenant)
+    if entry_id is None:
+        abort(404)
     entry = g.db.query(models.QueueEntry).filter_by(id=entry_id).first()
     if entry is None:
         abort(404)
@@ -140,7 +304,40 @@ def ticket(entry_id):
     estimate = get_estimator(g.db).estimate(entry)
     return render_template('queue/ticket.html', entry=entry, service_point=sp,
                            estimate=estimate, ahead=estimate.people_ahead,
-                           status_labels=STATUS_TH)
+                           status_labels=STATUS_TH,
+                           messaging_config=_messaging_config(),
+                           checkin_confirm=request.args.get('checkin_confirm') == '1',
+                           pwa_subscribe_url=build_url_with_context(
+                               'queue.ticket_pwa_subscription',
+                               token=token,
+                           ),
+                           service_worker_url=build_url_with_context('pwa.service_worker'))
+
+
+@queue_bp.route('/ticket/<token>/pwa-subscription', methods=['POST'])
+def ticket_pwa_subscription(token):
+    """Store a browser push subscription for the patient who owns this ticket."""
+    entry_id = read_ticket_token(token, g.tenant)
+    if entry_id is None:
+        abort(404)
+    entry = g.db.query(models.QueueEntry).filter_by(id=entry_id).first()
+    if entry is None:
+        abort(404)
+    config = _messaging_config()
+    if not config or config.pwa_status != 'active' or not config.pwa_vapid_public_key:
+        return jsonify({'linked': False, 'error': 'pwa_not_configured'}), 400
+
+    payload = request.get_json(silent=True) or {}
+    try:
+        link = mi.link_pwa_subscription_for_patient_ref(
+            g.db,
+            subscription=payload.get('subscription') or payload,
+            patient_ref=entry.patient_ref,
+        )
+    except mi.ChannelIdentityError as exc:
+        g.db.rollback()
+        return jsonify({'linked': False, 'error': str(exc)}), 400
+    return jsonify({'linked': True, 'channel': link.channel})
 
 
 # ============================ Staff: console ============================
@@ -162,11 +359,19 @@ def console(service_point_id):
     serving = (base.filter(models.QueueEntry.status.in_(('called', 'in_service')))
                .order_by(models.QueueEntry.queue_number.asc()).all())
     done_count = base.filter(models.QueueEntry.status == 'done').count()
+    messaging_config = _messaging_config()
+    checkin_links = messaging_links.build_checkin_links(
+        messaging_config,
+        request.url_root,
+        sp.id,
+        subdomain=g.subdomain,
+    )
 
     return render_template('queue/console.html', service_point=sp, day=day,
                            waiting=waiting, serving=serving, done_count=done_count,
                            in_service_count=sum(1 for e in serving if e.status == 'in_service'),
-                           status_labels=STATUS_TH)
+                           status_labels=STATUS_TH,
+                           checkin_links=checkin_links)
 
 
 @queue_bp.route('/console/<int:service_point_id>/call-next', methods=['POST'])
@@ -182,7 +387,8 @@ def call_next(service_point_id):
     if entry is None:
         flash('ไม่มีคิวที่รออยู่', 'info')
     else:
-        qn.enqueue_queue_turn(g.tenant, entry)
+        qn.enqueue_queue_turn(g.tenant, entry, url=build_url_with_context(
+            'queue.ticket', token=make_ticket_token(entry.id, g.tenant), _external=True))
         flash(f'เรียกคิวหมายเลข {entry.queue_number} แล้ว', 'success')
     return redirect(build_url_with_context('queue.console', service_point_id=sp.id))
 

--- a/hospital-booking/flask_app/app/routes.py
+++ b/hospital-booking/flask_app/app/routes.py
@@ -10,7 +10,8 @@ import logging
 from shared_db.models import (Appointment, User, Hospital, 
                               Provider, EventType, Patient, 
                               ServiceType, AvailabilityTemplate,
-                              TemplateProvider, AuditLog)
+                              TemplateProvider, AuditLog, MessagingConfig)
+from shared_db import crypto
 from .auth import login_required, check_tenant_access
 from .utils.logger import log_route_access
 from .utils.url_helper import get_dashboard_url, build_url_with_context
@@ -18,6 +19,7 @@ from .services.appointment_notifications import (
     notify_patient_appointment_change,
     notify_reschedule_request,
 )
+from .services import telegram_provisioning
 from shared_db.database import SessionLocal, get_db_session
 from .auth import get_current_user
 from .core.tenant_manager import with_tenant, TenantManager
@@ -1095,6 +1097,124 @@ def admin_check_database():
 def working_hours():
     """หน้าตั้งค่าเวลาทำการ (เก่า - redirect ไปใหม่)"""
     return redirect(build_url_with_context('availability.availability_settings'))
+
+
+def _deny_messaging_settings_access():
+    current_user = get_current_user()
+    hospital = getattr(current_user, 'hospital', None) if current_user else None
+    if not current_user or not hospital or hospital.subdomain != getattr(g, 'subdomain', None):
+        flash('ไม่สามารถเข้าถึงได้', 'error')
+        return redirect(build_url_with_context('main.index'))
+    return None
+
+
+def _tenant_messaging_config():
+    cfg = g.db.query(MessagingConfig).order_by(MessagingConfig.id.asc()).first()
+    if cfg is None:
+        cfg = MessagingConfig()
+        g.db.add(cfg)
+        g.db.flush()
+    return cfg
+
+
+def _choice(value, allowed, default):
+    return value if value in allowed else default
+
+
+@bp.route('/settings/messaging', methods=['GET', 'POST'])
+@login_required
+def messaging_settings():
+    """Tenant messaging channel settings (LINE / Telegram / PWA)."""
+    denied = _deny_messaging_settings_access()
+    if denied:
+        return denied
+
+    cfg = _tenant_messaging_config()
+    if request.method == 'POST':
+        section = request.form.get('section')
+        try:
+            if section == 'line':
+                cfg.line_channel_id = (request.form.get('line_channel_id') or '').strip() or None
+                cfg.line_login_channel_id = (request.form.get('line_login_channel_id') or '').strip() or None
+                cfg.line_liff_id = (request.form.get('line_liff_id') or '').strip() or None
+                cfg.line_status = _choice(
+                    request.form.get('line_status'),
+                    {'not_configured', 'active', 'disabled', 'error'},
+                    'not_configured',
+                )
+                line_secret = (request.form.get('line_channel_secret') or '').strip()
+                line_token = (request.form.get('line_channel_token') or '').strip()
+                if line_secret:
+                    cfg.line_channel_secret_enc = crypto.encrypt(line_secret)
+                if line_token:
+                    cfg.line_channel_token_enc = crypto.encrypt(line_token)
+                cfg.line_last_error = None if cfg.line_status == 'active' else cfg.line_last_error
+                g.db.commit()
+                flash('บันทึกการตั้งค่า LINE แล้ว', 'success')
+
+            elif section == 'telegram':
+                token = (request.form.get('telegram_bot_token') or '').strip()
+                ownership = _choice(
+                    request.form.get('telegram_bot_ownership'),
+                    {'tenant', 'saas'},
+                    'tenant',
+                )
+                mini_app_short_name = (request.form.get('telegram_mini_app_short_name') or '').strip() or None
+                web_app_url = (request.form.get('telegram_web_app_url') or '').strip() or None
+                if not web_app_url:
+                    # Default the Mini App menu to the tenant-bound deep-link router
+                    # (queue.enter forwards ?startapp=sp_<id> to check-in, else home).
+                    # build_url_with_context handles subdomain-host vs ?subdomain= modes;
+                    # the helper's own fallback uses ?tenant=<schema> which middleware ignores.
+                    web_app_url = build_url_with_context('queue.enter', _external=True)
+                if not token:
+                    cfg.telegram_bot_ownership = ownership
+                    cfg.telegram_mini_app_short_name = mini_app_short_name
+                    cfg.telegram_status = _choice(
+                        request.form.get('telegram_status'),
+                        {'not_configured', 'active', 'disabled', 'error'},
+                        cfg.telegram_status or 'not_configured',
+                    )
+                    g.db.commit()
+                    flash('บันทึก metadata Telegram แล้ว (ยังไม่ได้ provision token ใหม่)', 'success')
+                else:
+                    tenant_key = getattr(g, 'tenant', None) or getattr(getattr(g, 'hospital', None), 'schema_name', None)
+                    telegram_provisioning.provision_telegram_bot(
+                        g.db,
+                        tenant_key=tenant_key,
+                        token=token,
+                        ownership=ownership,
+                        public_base_url=request.url_root,
+                        mini_app_short_name=mini_app_short_name,
+                        web_app_url=web_app_url,
+                    )
+                    flash('Provision Telegram bot สำเร็จ', 'success')
+
+            elif section == 'pwa':
+                cfg.pwa_status = _choice(
+                    request.form.get('pwa_status'),
+                    {'disabled', 'active', 'error'},
+                    'disabled',
+                )
+                cfg.pwa_vapid_public_key = (request.form.get('pwa_vapid_public_key') or '').strip() or None
+                pwa_private_key = (request.form.get('pwa_vapid_private_key') or '').strip()
+                if pwa_private_key:
+                    cfg.pwa_vapid_private_key_enc = crypto.encrypt(pwa_private_key)
+                g.db.commit()
+                flash('บันทึกการตั้งค่า PWA แล้ว', 'success')
+            else:
+                flash('ไม่พบส่วนการตั้งค่าที่ต้องการบันทึก', 'error')
+        except telegram_provisioning.TelegramProvisioningError as exc:
+            g.db.rollback()
+            safe_message = str(exc)[:200] or 'บันทึกการตั้งค่าไม่สำเร็จ'
+            flash(safe_message, 'error')
+        except Exception:
+            g.db.rollback()
+            flash('บันทึกการตั้งค่าไม่สำเร็จ', 'error')
+
+        return redirect(build_url_with_context('main.messaging_settings'))
+
+    return render_template('settings/messaging.html', config=cfg)
 
 # @bp.route('/settings/availability')
 # @login_required  

--- a/hospital-booking/flask_app/app/services/analytics_service.py
+++ b/hospital-booking/flask_app/app/services/analytics_service.py
@@ -6,7 +6,12 @@ Business calculations stay in Python; templates only render precomputed values.
 import datetime
 from collections import Counter, defaultdict
 
-from shared_db import models
+import requests
+
+from shared_db import crypto, models
+
+LINE_QUOTA_URL = "https://api.line.me/v2/bot/message/quota"
+LINE_CONSUMPTION_URL = "https://api.line.me/v2/bot/message/quota/consumption"
 
 
 def _date_bounds(date_from, date_to):
@@ -129,3 +134,45 @@ def message_cost_summary(db, date_from, date_to):
         'by_channel': dict(by_channel),
         'by_event': dict(by_event),
     }
+
+
+def _line_quota_from_api(token, http_client=requests):
+    """Pure HTTP+math half of line_message_quota (no DB) — easy to unit test.
+
+    type='limited'  → {limit, used, remaining}
+    type='none'     → unlimited plan, nothing to count
+    4xx / bad data  → None (caller treats as 'unavailable')
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    r1 = http_client.get(LINE_QUOTA_URL, headers=headers, timeout=10)
+    if r1.status_code >= 400:
+        return None
+    quota = r1.json()
+    if quota.get("type") != "limited":
+        return {"type": quota.get("type") or "none", "limit": None, "used": None, "remaining": None}
+    r2 = http_client.get(LINE_CONSUMPTION_URL, headers=headers, timeout=10)
+    if r2.status_code >= 400:
+        return None
+    limit = int(quota.get("value") or 0)
+    used = int(r2.json().get("totalUsage") or 0)
+    return {"type": "limited", "limit": limit, "used": used, "remaining": max(0, limit - used)}
+
+
+def line_message_quota(db, http_client=requests):
+    """Live LINE push quota for this tenant (best-effort; None if not configured/down).
+
+    Spent cost comes from notification_log (message_cost_summary); this adds the
+    REMAINING side straight from LINE so staff see how close they are to the free
+    cap. Any network/credential error returns None — analytics must never 500
+    because LINE is unreachable.
+    """
+    config = db.query(models.MessagingConfig).order_by(models.MessagingConfig.id.asc()).first()
+    if not config or getattr(config, 'line_status', None) != 'active':
+        return None
+    token_enc = getattr(config, 'line_channel_token_enc', None)
+    if not token_enc:
+        return None
+    try:
+        return _line_quota_from_api(crypto.decrypt(token_enc), http_client=http_client)
+    except Exception:
+        return None

--- a/hospital-booking/flask_app/app/services/messaging_identity.py
+++ b/hospital-booking/flask_app/app/services/messaging_identity.py
@@ -1,0 +1,312 @@
+"""Signed messaging identity helpers for LINE/Telegram/PWA.
+
+Channel ownership alone is not a patient identity. These helpers only link a
+channel to a canonical patient_ref after the channel proof is verified and the
+patient_ref is resolved from server-side booking/phone data.
+"""
+
+from __future__ import annotations
+
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+import re
+from urllib.parse import parse_qs, parse_qsl, unquote_plus
+
+import requests
+
+from shared_db import crypto, models
+
+from . import identity_service
+
+_LINK_PREFIX_RE = re.compile(r"^(?:/start\s+|link[:=_-]?|ref[:=])(.+)$", re.IGNORECASE)
+
+
+class InitDataValidationError(ValueError):
+    """Telegram Mini App initData is missing, expired, or has an invalid hash."""
+
+
+class LineIdTokenError(ValueError):
+    """LINE LIFF ID token could not be verified by LINE."""
+
+
+class ChannelIdentityError(ValueError):
+    """The signed channel identity could not be linked to a patient_ref."""
+
+
+def get_config(db):
+    return db.query(models.MessagingConfig).order_by(models.MessagingConfig.id.asc()).first()
+
+
+def _canonical_ref_from_value(value) -> str | None:
+    if value is None:
+        return None
+    return identity_service.canonicalize_patient_ref(unquote_plus(str(value).strip()))
+
+
+def extract_patient_ref(value) -> str | None:
+    """Extract canonical patient_ref from query-like text or a direct ref token."""
+    if value is None:
+        return None
+    text_value = str(value).strip()
+    if not text_value:
+        return None
+
+    match = _LINK_PREFIX_RE.match(text_value)
+    if match:
+        text_value = match.group(1).strip()
+
+    if "?" in text_value:
+        text_value = text_value.split("?", 1)[1]
+
+    if "=" in text_value:
+        params = parse_qs(text_value, keep_blank_values=False)
+        for key in ("patient_ref", "ref"):
+            if key in params and params[key]:
+                ref = _canonical_ref_from_value(params[key][0])
+                if ref:
+                    return ref
+
+    return _canonical_ref_from_value(text_value)
+
+
+def upsert_channel_link(db, *, patient_ref: str | None, channel: str,
+                        external_id: str | None, raw_profile: dict | None = None):
+    canonical_ref = identity_service.canonicalize_patient_ref(patient_ref)
+    if not canonical_ref or not external_id:
+        return None
+    link = (db.query(models.ChannelLink)
+            .filter_by(channel=channel, external_id=str(external_id))
+            .one_or_none())
+    if link is None:
+        link = models.ChannelLink(
+            patient_ref=canonical_ref,
+            channel=channel,
+            external_id=str(external_id),
+            is_active=True,
+            raw_profile=raw_profile or {},
+        )
+        db.add(link)
+    else:
+        link.patient_ref = canonical_ref
+        link.is_active = True
+        link.raw_profile = raw_profile or {}
+    db.flush()
+    return link
+
+
+def resolve_patient_ref_from_inputs(db, *, booking_reference: str | None = None,
+                                    patient_phone: str | None = None) -> str:
+    """Resolve patient_ref from a booking_reference (the identity proof).
+
+    SECURITY: a self-asserted phone number is NOT proof of ownership — without an
+    SMS/voice OTP anyone could claim another person's phone and hijack their queue
+    notifications. (OTP via LINE/Telegram can't verify a phone: you'd already need a
+    link to that person to deliver it — circular.) So identity MUST be established
+    via the per-patient secret `booking_reference`; `patient_phone` is only a
+    secondary hint to pick the ref from the resolved appointment, never a standalone
+    identity. Walk-ins (no booking_reference) link via their ticket context instead.
+    """
+    booking_reference = (booking_reference or "").strip()
+    patient_phone = (patient_phone or "").strip()
+
+    if not booking_reference:
+        raise ChannelIdentityError("booking_reference_required")
+
+    appointment = (db.query(models.Appointment)
+                   .filter_by(booking_reference=booking_reference)
+                   .one_or_none())
+    if appointment is None:
+        raise ChannelIdentityError("booking_reference_not_found")
+    patient_ref = identity_service.resolve_patient_ref(
+        appointment=appointment,
+        phone=patient_phone,
+        required=False,
+    )
+
+    if not patient_ref:
+        raise ChannelIdentityError("patient_ref_required")
+    return patient_ref
+
+
+def verify_line_signature(secret: str | None, body: bytes, signature: str | None) -> bool:
+    if not secret or not signature:
+        return False
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).digest()
+    expected = base64.b64encode(digest).decode("ascii")
+    return hmac.compare_digest(expected, signature)
+
+
+def verify_line_id_token(config, id_token: str | None, http_client=requests) -> dict:
+    """Verify a LIFF ID token via LINE and return trusted claims.
+
+    The ID token itself is never logged or persisted. LINE's verify endpoint
+    performs signature validation; we still enforce `aud` against the tenant's
+    Login channel id because Messaging channel id is not interchangeable here.
+    """
+    id_token = (id_token or "").strip()
+    login_channel_id = getattr(config, "line_login_channel_id", None)
+    if not id_token:
+        raise LineIdTokenError("id_token_missing")
+    if not login_channel_id:
+        raise LineIdTokenError("line_login_channel_missing")
+
+    try:
+        response = http_client.post(
+            "https://api.line.me/oauth2/v2.1/verify",
+            data={"id_token": id_token, "client_id": login_channel_id},
+            timeout=10,
+        )
+    except requests.RequestException as exc:
+        raise LineIdTokenError("line_id_token_verify_failed") from exc
+
+    if response.status_code >= 400:
+        raise LineIdTokenError("line_id_token_invalid")
+
+    try:
+        claims = response.json()
+    except ValueError as exc:
+        raise LineIdTokenError("line_id_token_invalid") from exc
+
+    if str(claims.get("aud") or "") != str(login_channel_id):
+        raise LineIdTokenError("line_id_token_audience_mismatch")
+    if not claims.get("sub"):
+        raise LineIdTokenError("line_user_missing")
+    return claims
+
+
+def link_line_identity(db, *, config=None, id_token: str | None = None,
+                       booking_reference: str | None = None,
+                       patient_phone: str | None = None,
+                       http_client=requests):
+    config = config or get_config(db)
+    claims = verify_line_id_token(config, id_token, http_client=http_client)
+    patient_ref = resolve_patient_ref_from_inputs(
+        db,
+        booking_reference=booking_reference,
+        patient_phone=patient_phone,
+    )
+    link = upsert_channel_link(
+        db,
+        patient_ref=patient_ref,
+        channel="line",
+        external_id=claims["sub"],
+        raw_profile={"source": "liff_id_token", "name": claims.get("name")},
+    )
+    db.commit()
+    return link
+
+
+def verify_telegram_secret(config, header_secret: str | None) -> bool:
+    if not config or not header_secret or not getattr(config, "telegram_webhook_secret_enc", None):
+        return False
+    expected = crypto.decrypt(config.telegram_webhook_secret_enc)
+    return hmac.compare_digest(expected or "", header_secret)
+
+
+def validate_telegram_init_data(config, init_data: str, *,
+                                now: int | None = None, max_age_seconds: int = 300) -> dict:
+    if not init_data:
+        raise InitDataValidationError("initData missing")
+    if not config or not getattr(config, "telegram_bot_token_enc", None):
+        raise InitDataValidationError("telegram bot token missing")
+
+    pairs = dict(parse_qsl(init_data, keep_blank_values=True, strict_parsing=False))
+    supplied_hash = pairs.pop("hash", None)
+    if not supplied_hash:
+        raise InitDataValidationError("hash missing")
+
+    try:
+        auth_date = int(pairs.get("auth_date", "0"))
+    except ValueError as exc:
+        raise InitDataValidationError("auth_date invalid") from exc
+    now_ts = int(now if now is not None else datetime.datetime.now(datetime.timezone.utc).timestamp())
+    if auth_date <= 0 or now_ts - auth_date > max_age_seconds or auth_date - now_ts > 60:
+        raise InitDataValidationError("initData expired")
+
+    data_check_string = "\n".join(f"{key}={pairs[key]}" for key in sorted(pairs))
+    token = crypto.decrypt(config.telegram_bot_token_enc)
+    secret_key = hmac.new(b"WebAppData", token.encode("utf-8"), hashlib.sha256).digest()
+    expected_hash = hmac.new(secret_key, data_check_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(expected_hash, supplied_hash):
+        raise InitDataValidationError("hash invalid")
+
+    parsed = dict(pairs)
+    if "user" in parsed:
+        try:
+            parsed["user"] = json.loads(parsed["user"])
+        except json.JSONDecodeError as exc:
+            raise InitDataValidationError("user JSON invalid") from exc
+    return parsed
+
+
+def link_telegram_identity(db, *, config=None, init_data: str | None = None,
+                           booking_reference: str | None = None,
+                           patient_phone: str | None = None,
+                           now: int | None = None):
+    config = config or get_config(db)
+    data = validate_telegram_init_data(config, init_data or "", now=now)
+    user = data.get("user") or {}
+    telegram_user_id = user.get("id")
+    if telegram_user_id is None:
+        raise ChannelIdentityError("telegram_user_missing")
+
+    patient_ref = resolve_patient_ref_from_inputs(
+        db,
+        booking_reference=booking_reference,
+        patient_phone=patient_phone,
+    )
+    link = upsert_channel_link(
+        db,
+        patient_ref=patient_ref,
+        channel="telegram",
+        external_id=str(telegram_user_id),
+        raw_profile={"source": "telegram_init_data", "username": user.get("username")},
+    )
+    db.commit()
+    return link
+
+
+def link_pwa_subscription(db, *, subscription: dict | None,
+                          booking_reference: str | None = None,
+                          patient_phone: str | None = None):
+    subscription = subscription or {}
+    endpoint = subscription.get("endpoint")
+    if not endpoint:
+        raise ChannelIdentityError("pwa_endpoint_missing")
+    patient_ref = resolve_patient_ref_from_inputs(
+        db,
+        booking_reference=booking_reference,
+        patient_phone=patient_phone,
+    )
+    link = upsert_channel_link(
+        db,
+        patient_ref=patient_ref,
+        channel="pwa",
+        external_id=endpoint,
+        raw_profile=subscription,
+    )
+    db.commit()
+    return link
+
+
+def link_pwa_subscription_for_patient_ref(db, *, subscription: dict | None,
+                                          patient_ref: str | None):
+    subscription = subscription or {}
+    endpoint = subscription.get("endpoint")
+    if not endpoint:
+        raise ChannelIdentityError("pwa_endpoint_missing")
+    canonical_ref = identity_service.canonicalize_patient_ref(patient_ref)
+    if not canonical_ref:
+        raise ChannelIdentityError("patient_ref_required")
+    link = upsert_channel_link(
+        db,
+        patient_ref=canonical_ref,
+        channel="pwa",
+        external_id=endpoint,
+        raw_profile=subscription,
+    )
+    db.commit()
+    return link

--- a/hospital-booking/flask_app/app/services/messaging_links.py
+++ b/hospital-booking/flask_app/app/services/messaging_links.py
@@ -1,0 +1,58 @@
+"""Channel entry links for QR/check-in surfaces (Phase 4.5 / 4.10)."""
+
+from __future__ import annotations
+
+from urllib.parse import quote, urlencode
+
+
+def _base(public_base_url: str) -> str:
+    return (public_base_url or "").rstrip("/")
+
+
+def web_checkin_url(public_base_url: str, service_point_id: int, *, subdomain: str | None = None) -> str:
+    url = f"{_base(public_base_url)}/queue/checkin/{int(service_point_id)}"
+    if subdomain:
+        return f"{url}?{urlencode({'subdomain': subdomain})}"
+    return url
+
+
+def line_liff_checkin_url(config, public_base_url: str, service_point_id: int,
+                          *, subdomain: str | None = None) -> str | None:
+    liff_id = getattr(config, "line_liff_id", None)
+    if not liff_id:
+        return None
+    checkin_url = web_checkin_url(public_base_url, service_point_id, subdomain=subdomain)
+    params = {
+        "service_point_id": int(service_point_id),
+        "checkin_url": checkin_url,
+    }
+    return f"https://liff.line.me/{quote(str(liff_id), safe='')}?{urlencode(params)}"
+
+
+def telegram_checkin_url(config, service_point_id: int) -> str | None:
+    username = getattr(config, "telegram_bot_username", None)
+    if not username:
+        return None
+    start_param = f"sp_{int(service_point_id)}"
+    short_name = getattr(config, "telegram_mini_app_short_name", None)
+    if short_name:
+        return (
+            f"https://t.me/{quote(str(username), safe='')}/"
+            f"{quote(str(short_name), safe='')}?{urlencode({'startapp': start_param})}"
+        )
+    return f"https://t.me/{quote(str(username), safe='')}?{urlencode({'start': start_param})}"
+
+
+def build_checkin_links(config, public_base_url: str, service_point_id: int,
+                        *, subdomain: str | None = None) -> dict:
+    links = {
+        "web": web_checkin_url(public_base_url, service_point_id, subdomain=subdomain),
+        "line_liff": line_liff_checkin_url(
+            config,
+            public_base_url,
+            service_point_id,
+            subdomain=subdomain,
+        ),
+        "telegram": telegram_checkin_url(config, service_point_id),
+    }
+    return {key: value for key, value in links.items() if value}

--- a/hospital-booking/flask_app/app/services/notify_service.py
+++ b/hospital-booking/flask_app/app/services/notify_service.py
@@ -22,6 +22,11 @@ PAID_CHANNELS = {'line_push'}
 DEFAULT_PRIORITY = ['telegram', 'pwa', 'line_push']
 RESPONSIVE_EVENTS = {'booking_confirm', 'checkin_confirm'}
 
+try:
+    from pywebpush import webpush as _webpush
+except ImportError:  # pragma: no cover - optional production dependency
+    _webpush = None
+
 
 @dataclass(frozen=True)
 class NotificationResult:
@@ -220,6 +225,32 @@ def _send_line_reply(config, reply_token, event_type, context):
     return data is not None
 
 
+def _send_pwa(config, link, event_type, context):
+    if _webpush is None or link is None:
+        return False
+    if not getattr(config, 'pwa_vapid_private_key_enc', None):
+        return False
+    subscription = link.raw_profile
+    if not isinstance(subscription, dict) or not subscription.get('endpoint'):
+        return False
+    private_key = crypto.decrypt(config.pwa_vapid_private_key_enc)
+    payload = json.dumps({
+        "title": "NudDee",
+        "body": _message_text(event_type, context),
+        "url": (context or {}).get("url") or "/",
+    }, ensure_ascii=False)
+    try:
+        _webpush(
+            subscription_info=subscription,
+            data=payload,
+            vapid_private_key=private_key,
+            vapid_claims={"sub": "mailto:noreply@nuddee.com"},
+        )
+    except Exception:  # noqa: BLE001 - transport failure falls through to next channel
+        return False
+    return True
+
+
 def _default_sender(channel=None, event_type=None, context=None, reply_token=None,
                     link=None, config=None, **kwargs):
     """Default transports for server-side async/sync messaging channels."""
@@ -229,7 +260,9 @@ def _default_sender(channel=None, event_type=None, context=None, reply_token=Non
         return _send_line_push(config, link, event_type, context)
     if channel == 'line_reply':
         return _send_line_reply(config, reply_token, event_type, context)
-    # PWA and LIFF client-side sends are wired in their own channel phases.
+    if channel == 'pwa':
+        return _send_pwa(config, link, event_type, context)
+    # LIFF client-side sends are wired in their own channel phase.
     return False
 
 

--- a/hospital-booking/flask_app/app/services/queue_notifications.py
+++ b/hospital-booking/flask_app/app/services/queue_notifications.py
@@ -86,27 +86,36 @@ def enqueue_queue_event(
 
 
 def enqueue_for_entry(schema_name: str | None, entry: models.QueueEntry,
-                      event_type: str, urgency: str) -> bool:
+                      event_type: str, urgency: str, *, url: str | None = None) -> bool:
+    context = _entry_context(entry)
+    if url:
+        # PWA push click target (patient's signed ticket). Built at enqueue time in the
+        # request, where url_helper knows subdomain vs host mode — the worker has no
+        # request context. Without it _send_pwa falls back to "/" (wrong page).
+        context["url"] = url
     return enqueue_queue_event(
         schema_name,
         entry.id,
         event_type,
         urgency,
-        context=_entry_context(entry),
+        context=context,
     )
 
 
-def enqueue_checkin_confirm(schema_name: str | None, entry: models.QueueEntry) -> bool:
-    return enqueue_for_entry(schema_name, entry, "checkin_confirm", "normal")
+def enqueue_checkin_confirm(schema_name: str | None, entry: models.QueueEntry,
+                            *, url: str | None = None) -> bool:
+    return enqueue_for_entry(schema_name, entry, "checkin_confirm", "normal", url=url)
 
 
-def enqueue_queue_turn(schema_name: str | None, entry: models.QueueEntry) -> bool:
-    return enqueue_for_entry(schema_name, entry, "queue_turn", "critical")
+def enqueue_queue_turn(schema_name: str | None, entry: models.QueueEntry,
+                       *, url: str | None = None) -> bool:
+    return enqueue_for_entry(schema_name, entry, "queue_turn", "critical", url=url)
 
 
-def enqueue_queue_near(schema_name: str | None, entry: models.QueueEntry) -> bool:
+def enqueue_queue_near(schema_name: str | None, entry: models.QueueEntry,
+                       *, url: str | None = None) -> bool:
     # Hook for the future near-turn detector; call_next currently wires queue_turn only.
-    return enqueue_for_entry(schema_name, entry, "queue_near", "critical")
+    return enqueue_for_entry(schema_name, entry, "queue_near", "critical", url=url)
 
 
 def _validate_schema_name(schema_name: str) -> None:

--- a/hospital-booking/flask_app/app/services/telegram_pool.py
+++ b/hospital-booking/flask_app/app/services/telegram_pool.py
@@ -1,0 +1,95 @@
+"""Control-plane helpers for SaaS-managed Telegram account pool (§4.11)."""
+
+from __future__ import annotations
+
+from sqlalchemy import func
+
+from shared_db import models
+
+
+class PoolExhausted(RuntimeError):
+    """No active SaaS Telegram account has remaining bot capacity."""
+
+
+class TelegramPoolError(RuntimeError):
+    """Telegram pool allocation or registration failed."""
+
+
+def _allocated_count(db, account_id: int) -> int:
+    return (db.query(func.count(models.SaasTelegramBot.id))
+            .filter(models.SaasTelegramBot.saas_account_id == account_id,
+                    models.SaasTelegramBot.status == "allocated")
+            .scalar() or 0)
+
+
+def allocate_account(db) -> models.SaasTelegramAccount:
+    """Return an active account with remaining capacity.
+
+    This is an advisory selection step. `register_bot()` re-checks capacity under
+    row lock before inserting the allocation, so concurrent onboarding cannot
+    overfill an account.
+    """
+    accounts = (db.query(models.SaasTelegramAccount)
+                .filter(models.SaasTelegramAccount.status == "active")
+                .order_by(models.SaasTelegramAccount.id.asc())
+                .all())
+    for account in accounts:
+        if _allocated_count(db, account.id) < int(account.bot_capacity):
+            return account
+    raise PoolExhausted("telegram account pool exhausted")
+
+
+def register_bot(db, *, saas_account_id: int, tenant_schema: str,
+                 bot_username: str) -> models.SaasTelegramBot:
+    """Register a created bot to a tenant after BotFather setup.
+
+    The account row is locked and capacity is re-counted before insert. Tokens
+    are not accepted here and must stay in tenant.messaging_config encrypted.
+    """
+    tenant_schema = (tenant_schema or "").strip()
+    bot_username = (bot_username or "").strip().lstrip("@")
+    if not tenant_schema:
+        raise TelegramPoolError("tenant_schema is required")
+    if not bot_username:
+        raise TelegramPoolError("bot_username is required")
+
+    account = (db.query(models.SaasTelegramAccount)
+               .filter(models.SaasTelegramAccount.id == saas_account_id)
+               .with_for_update()
+               .one_or_none())
+    if account is None:
+        raise TelegramPoolError("telegram account not found")
+
+    # Idempotency check BEFORE the status gate: a retry of an allocation that
+    # already filled this account (status now "full") must still return that
+    # allocation rather than fail with PoolExhausted.
+    existing = (db.query(models.SaasTelegramBot)
+                .filter(models.SaasTelegramBot.tenant_schema == tenant_schema,
+                        models.SaasTelegramBot.status == "allocated")
+                .one_or_none())
+    if existing is not None:
+        if existing.saas_account_id == account.id and existing.bot_username == bot_username:
+            return existing
+        raise TelegramPoolError("tenant already has an allocated Telegram bot")
+
+    if account.status != "active":
+        raise PoolExhausted("telegram account is not active")
+
+    allocated = _allocated_count(db, account.id)
+    if allocated >= int(account.bot_capacity):
+        account.status = "full"
+        db.commit()
+        raise PoolExhausted("telegram account capacity reached")
+
+    bot = models.SaasTelegramBot(
+        saas_account_id=account.id,
+        tenant_schema=tenant_schema,
+        bot_username=bot_username,
+        status="allocated",
+    )
+    db.add(bot)
+    if allocated + 1 >= int(account.bot_capacity):
+        account.status = "full"
+    db.commit()
+    db.refresh(bot)
+    return bot

--- a/hospital-booking/flask_app/app/static/js/queue_mini_app.js
+++ b/hospital-booking/flask_app/app/static/js/queue_mini_app.js
@@ -1,0 +1,250 @@
+(function () {
+  "use strict";
+
+  const cfg = window.NUDDEE_MINI_APP || {};
+
+  // --- Deep-link router (Phase 4.5/4.10) -----------------------------------
+  // The /queue/enter page (it sets entryDefaultUrl) is the Mini App / LIFF entry:
+  // it resolves the deep link and forwards to the right check-in page.
+  //   • Telegram direct Mini App (?startapp=sp_<id>) → tgWebAppStartParam in the hash
+  //   • LINE LIFF → service_point_id / ready-made checkin_url, delivered INSIDE
+  //     liff.state on the primary redirect (may only surface after liff.init()).
+  function sameOrigin(url) {
+    try { return new URL(url, window.location.href).origin === window.location.origin; }
+    catch (_) { return false; }
+  }
+
+  function deepLinkTarget() {
+    const params = new URLSearchParams(
+      (window.location.search || "").replace(/^\?/, "") +
+      "&" + (window.location.hash || "").replace(/^#/, "")
+    );
+    // LINE LIFF carries the original query inside liff.state — fold it in.
+    const liffState = params.get("liff.state");
+    if (liffState) {
+      const q = liffState.indexOf("?") >= 0 ? liffState.slice(liffState.indexOf("?") + 1) : liffState;
+      new URLSearchParams(q).forEach((value, key) => {
+        if (!params.has(key)) params.set(key, value);
+      });
+    }
+    const checkinUrl = params.get("checkin_url");
+    if (checkinUrl && sameOrigin(checkinUrl)) return checkinUrl;   // else: open-redirect, ignore
+    let sp = params.get("service_point_id");
+    if (!sp) {
+      const m = /^sp_(\d+)$/.exec(params.get("startapp") || params.get("tgWebAppStartParam") || "");
+      if (m) sp = m[1];
+    }
+    if (!sp || !/^\d+$/.test(sp)) return null;
+    const sub = params.get("subdomain");   // keep tenant context in query mode; drop liff.state noise
+    return `/queue/checkin/${sp}${sub ? `?subdomain=${encodeURIComponent(sub)}` : ""}`;
+  }
+
+  if (cfg.entryDefaultUrl !== undefined) {
+    // Entry page: resolve + forward, then stop. For LINE, liff.state may only resolve
+    // after liff.init() (the documented primary-redirect flow) — try it best-effort.
+    (async function () {
+      let target = deepLinkTarget();
+      if (!target && cfg.lineLiffId) {
+        try {
+          await loadScript("https://static.line-scdn.net/liff/edge/2/sdk.js");
+          await window.liff.init({ liffId: cfg.lineLiffId });
+          target = deepLinkTarget();
+        } catch (_) { /* fall through to the default */ }
+      }
+      window.location.replace(target || cfg.entryDefaultUrl);
+    })();
+    return;
+  }
+
+  const csrf = document.querySelector('meta[name="csrf-token"]')?.content || "";
+  const form = document.querySelector("[data-mini-app-checkin-form]");
+  const pwaButton = document.querySelector("[data-pwa-subscribe]");
+  const pwaStatus = document.querySelector("[data-pwa-status]");
+  let context = { type: "web" };
+  let submitted = false;
+  let confirmSent = false;
+
+  function loadScript(src) {
+    return new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[src="${src}"]`);
+      if (existing) {
+        existing.addEventListener("load", resolve, { once: true });
+        existing.addEventListener("error", reject, { once: true });
+        if (existing.dataset.loaded === "1") resolve();
+        return;
+      }
+      const script = document.createElement("script");
+      script.src = src;
+      script.async = true;
+      script.onload = () => {
+        script.dataset.loaded = "1";
+        resolve();
+      };
+      script.onerror = reject;
+      document.head.appendChild(script);
+    });
+  }
+
+  function withTimeout(promise, ms) {
+    return Promise.race([
+      promise,
+      new Promise((resolve) => window.setTimeout(resolve, ms)),
+    ]);
+  }
+
+  function isTelegramLaunch() {
+    const marker = `${window.location.search || ""}${window.location.hash || ""}`;
+    return marker.indexOf("tgWebAppData=") !== -1 || /Telegram/i.test(navigator.userAgent);
+  }
+
+  function isLineLaunch() {
+    return Boolean(cfg.lineLiffId) && /\bLine\//i.test(navigator.userAgent);
+  }
+
+  async function setupTelegram() {
+    if (!isTelegramLaunch()) return false;
+    await loadScript("https://telegram.org/js/telegram-web-app.js");
+    const webApp = window.Telegram && window.Telegram.WebApp;
+    if (!webApp || !webApp.initData) return false;
+    webApp.ready();
+    if (typeof webApp.expand === "function") webApp.expand();
+    context = { type: "telegram", initData: webApp.initData };
+    document.documentElement.dataset.nuddeeChannel = "telegram";
+    return true;
+  }
+
+  async function setupLine() {
+    if (!isLineLaunch()) return false;
+    await loadScript("https://static.line-scdn.net/liff/edge/2/sdk.js");
+    if (!window.liff) return false;
+    await window.liff.init({ liffId: cfg.lineLiffId });
+    if (!window.liff.isLoggedIn()) return false;
+    const idToken = window.liff.getIDToken();
+    if (!idToken) return false;
+    context = { type: "line", idToken };
+    document.documentElement.dataset.nuddeeChannel = "line";
+    return true;
+  }
+
+  async function detectContext() {
+    try {
+      if (await setupTelegram()) return context;
+    } catch (_) {
+      context = { type: "web" };
+    }
+    try {
+      if (await setupLine()) return context;
+    } catch (_) {
+      context = { type: "web" };
+    }
+    return context;
+  }
+
+  const ready = detectContext();
+
+  async function linkCurrentChannel() {
+    if (!cfg.channelAuthUrl || !form || context.type === "web") return;
+    const payload = {
+      channel: context.type,
+      booking_reference: form.elements.booking_reference?.value || "",
+      patient_phone: form.elements.patient_phone?.value || "",
+    };
+    if (!payload.booking_reference && !payload.patient_phone) return;
+    if (context.type === "line") payload.idToken = context.idToken;
+    if (context.type === "telegram") payload.initData = context.initData;
+
+    await fetch(cfg.channelAuthUrl, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRFToken": csrf,
+      },
+      credentials: "same-origin",
+      body: JSON.stringify(payload),
+    });
+  }
+
+  async function sendLineCheckinConfirm() {
+    if (!cfg.checkinConfirm || confirmSent || !cfg.confirmationText) return;
+    await withTimeout(ready, 1500);
+    if (context.type !== "line" || !window.liff || !window.liff.isInClient()) return;
+    confirmSent = true;
+    const url = new URL(window.location.href);
+    url.searchParams.delete("checkin_confirm");
+    window.history.replaceState({}, document.title, url.toString());
+    try {
+      await window.liff.sendMessages([{ type: "text", text: cfg.confirmationText }]);
+    } catch (_) {
+      confirmSent = false;
+    }
+  }
+
+  function setPwaStatus(message) {
+    if (pwaStatus) pwaStatus.textContent = message;
+  }
+
+  function base64UrlToUint8Array(value) {
+    const padding = "=".repeat((4 - (value.length % 4)) % 4);
+    const base64 = (value + padding).replace(/-/g, "+").replace(/_/g, "/");
+    const raw = window.atob(base64);
+    const output = new Uint8Array(raw.length);
+    for (let i = 0; i < raw.length; i += 1) {
+      output[i] = raw.charCodeAt(i);
+    }
+    return output;
+  }
+
+  async function subscribePwa() {
+    if (!cfg.pwaSubscribeUrl || !cfg.serviceWorkerUrl || !cfg.vapidPublicKey) return;
+    if (!("serviceWorker" in navigator) || !("PushManager" in window)) {
+      setPwaStatus("เบราว์เซอร์นี้ยังไม่รองรับ Web Push");
+      return;
+    }
+    pwaButton.disabled = true;
+    setPwaStatus("กำลังขอสิทธิ์แจ้งเตือน...");
+    try {
+      const permission = await window.Notification.requestPermission();
+      if (permission !== "granted") {
+        setPwaStatus("ยังไม่ได้อนุญาตการแจ้งเตือน");
+        pwaButton.disabled = false;
+        return;
+      }
+      const registration = await navigator.serviceWorker.register(cfg.serviceWorkerUrl);
+      const subscription = await registration.pushManager.subscribe({
+        userVisibleOnly: true,
+        applicationServerKey: base64UrlToUint8Array(cfg.vapidPublicKey),
+      });
+      const response = await fetch(cfg.pwaSubscribeUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": csrf,
+        },
+        credentials: "same-origin",
+        body: JSON.stringify({ subscription: subscription.toJSON() }),
+      });
+      if (!response.ok) throw new Error("subscribe failed");
+      setPwaStatus("เปิดรับแจ้งเตือนผ่านเว็บแล้ว");
+    } catch (_) {
+      pwaButton.disabled = false;
+      setPwaStatus("เปิดรับแจ้งเตือนไม่สำเร็จ");
+    }
+  }
+
+  if (form) {
+    form.addEventListener("submit", async (event) => {
+      if (submitted) return;
+      event.preventDefault();
+      submitted = true;
+      await withTimeout(ready, 1500);
+      await withTimeout(linkCurrentChannel(), 2500);
+      form.submit();
+    });
+  }
+
+  if (pwaButton) {
+    pwaButton.addEventListener("click", subscribePwa);
+  }
+
+  sendLineCheckinConfirm();
+})();

--- a/hospital-booking/flask_app/app/templates/analytics/index.html
+++ b/hospital-booking/flask_app/app/templates/analytics/index.html
@@ -98,6 +98,26 @@
                         <span class="font-semibold text-gray-900">{{ count }}</span>
                     </div>
                 {% endfor %}
+
+                {% if line_quota and line_quota.type == 'limited' %}
+                    <div class="pt-3 mt-2 border-t border-gray-100">
+                        <p class="text-xs font-semibold text-gray-500 mb-1">LINE โควตา push (เดือนนี้)</p>
+                        <div class="flex justify-between text-sm">
+                            <span class="text-gray-600">เหลือ / ทั้งหมด</span>
+                            <span class="font-semibold text-gray-900">
+                                {{ '{:,}'.format(line_quota.remaining) }} / {{ '{:,}'.format(line_quota.limit) }}
+                            </span>
+                        </div>
+                        <div class="flex justify-between text-sm">
+                            <span class="text-gray-600">ใช้ไปแล้ว</span>
+                            <span class="font-semibold text-gray-900">{{ '{:,}'.format(line_quota.used) }}</span>
+                        </div>
+                    </div>
+                {% elif line_quota and line_quota.type == 'none' %}
+                    <div class="pt-3 mt-2 border-t border-gray-100 text-sm text-gray-500">
+                        LINE: แพ็กเกจไม่จำกัดจำนวนข้อความ
+                    </div>
+                {% endif %}
             </div>
         </section>
     </div>

--- a/hospital-booking/flask_app/app/templates/base.html
+++ b/hospital-booking/flask_app/app/templates/base.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>{% block title %}NudDee{% endblock %}</title>
+    <link rel="manifest" href="{{ url('pwa.manifest') }}">
+    <meta name="theme-color" content="#6d28d9">
 
     <!-- สำหรับ favicon.ico error: ไม่ต้องกังวลครับ เป็นเพราะไม่มีไฟล์ favicon 
      แต่ไม่กระทบการทำงานของระบบ ถ้าอยากแก้ให้เพิ่มไฟล์ favicon.ico 

--- a/hospital-booking/flask_app/app/templates/partials/navbar.html
+++ b/hospital-booking/flask_app/app/templates/partials/navbar.html
@@ -57,6 +57,9 @@
                         <a href="{{ url('providers.provider_list') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
                             👥 จัดการผู้ให้บริการ
                         </a>
+                        <a href="{{ url('main.messaging_settings') }}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-100">
+                            💬 Messaging Channels
+                        </a>
                         <!-- Public Booking Link -->
                         {% if nav_params.subdomain %}
                         <div class="border-t mt-2 pt-2">

--- a/hospital-booking/flask_app/app/templates/queue/checkin.html
+++ b/hospital-booking/flask_app/app/templates/queue/checkin.html
@@ -7,6 +7,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
     <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>เช็คอิน — {{ service_point.name }}</title>
+    <link rel="manifest" href="{{ url('pwa.manifest') }}">
+    <meta name="theme-color" content="#6d28d9">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Sarabun:wght@300;400;600;700&display=swap" rel="stylesheet">
     <style>
@@ -41,7 +43,8 @@
           {% endif %}
         {% endwith %}
 
-        <form method="POST" class="bg-white rounded-xl shadow-md p-6 space-y-4">
+        <form method="POST" class="bg-white rounded-xl shadow-md p-6 space-y-4"
+              data-mini-app-checkin-form>
             <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
 
             <div>
@@ -86,5 +89,14 @@
 
         <p class="text-center text-xs text-gray-400 mt-4">นัดดี · NudDee</p>
     </div>
+    <script>
+      window.NUDDEE_MINI_APP = {
+        servicePointId: {{ service_point.id|tojson }},
+        channelAuthUrl: {{ channel_auth_url|tojson }},
+        lineLiffId: {{ (messaging_config.line_liff_id if messaging_config else '')|tojson }},
+        checkinConfirm: false
+      };
+    </script>
+    <script src="{{ url_for('static', filename='js/queue_mini_app.js') }}"></script>
 </body>
 </html>

--- a/hospital-booking/flask_app/app/templates/queue/console.html
+++ b/hospital-booking/flask_app/app/templates/queue/console.html
@@ -48,6 +48,24 @@
         </button>
     </form>
 
+    {% if checkin_links %}
+    <section class="bg-white rounded-xl shadow-md p-4 mb-8">
+        <h2 class="text-lg font-semibold text-gray-900 mb-3">ลิงก์สำหรับ QR เช็คอิน</h2>
+        <div class="space-y-2">
+            {% for channel, link in checkin_links.items() %}
+            <div class="text-sm">
+                <span class="inline-block w-24 text-gray-500">
+                    {{ {'web': 'เว็บ', 'line_liff': 'LINE', 'telegram': 'Telegram'}.get(channel, channel) }}
+                </span>
+                <a href="{{ link }}" target="_blank" class="text-purple-600 hover:text-purple-700 break-all">
+                    {{ link }}
+                </a>
+            </div>
+            {% endfor %}
+        </div>
+    </section>
+    {% endif %}
+
     <!-- serving -->
     <h2 class="text-xl font-semibold text-gray-900 mb-3">กำลังเรียก / รับบริการ</h2>
     {% if serving %}

--- a/hospital-booking/flask_app/app/templates/queue/enter.html
+++ b/hospital-booking/flask_app/app/templates/queue/enter.html
@@ -1,0 +1,25 @@
+<!-- templates/queue/enter.html — Mini App / LIFF entry router (deep-link → check-in) -->
+<!DOCTYPE html>
+<html lang="th">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <title>กำลังเปิด NudDee…</title>
+    <style>
+      body { font-family: -apple-system, 'Sarabun', sans-serif; min-height: 100vh; margin: 0;
+             display: flex; align-items: center; justify-content: center; color: #6b7280; }
+    </style>
+</head>
+<body>
+    <p>กำลังเปิด…</p>
+    <script>
+      // queue_mini_app.js reads the deep-link param and redirects; if none, it goes here.
+      // lineLiffId lets it run liff.init() to resolve LINE's liff.state params.
+      window.NUDDEE_MINI_APP = {
+        entryDefaultUrl: {{ default_url|tojson }},
+        lineLiffId: {{ (line_liff_id or '')|tojson }}
+      };
+    </script>
+    <script src="{{ url_for('static', filename='js/queue_mini_app.js') }}"></script>
+</body>
+</html>

--- a/hospital-booking/flask_app/app/templates/queue/ticket.html
+++ b/hospital-booking/flask_app/app/templates/queue/ticket.html
@@ -4,7 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
     <title>คิวหมายเลข {{ entry.queue_number }} — {{ service_point.name }}</title>
+    <link rel="manifest" href="{{ url('pwa.manifest') }}">
+    <meta name="theme-color" content="#6d28d9">
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Sarabun:wght@300;400;600;700&display=swap" rel="stylesheet">
     <style> body { font-family: 'Sarabun', sans-serif; } </style>
@@ -41,10 +44,33 @@
                 <span class="text-sm font-semibold text-purple-700">~{{ estimate.wait_minutes|round|int }} นาที</span>
             </div>
 
+            {% if messaging_config and messaging_config.pwa_status == 'active' and messaging_config.pwa_vapid_public_key %}
+            <div class="mt-6 pt-4 border-t border-gray-100">
+                <button type="button"
+                        data-pwa-subscribe
+                        class="w-full py-2.5 px-4 rounded-lg bg-gray-900 text-white text-sm font-medium
+                               hover:bg-gray-800 transition-colors">
+                    รับแจ้งเตือนผ่านเว็บ
+                </button>
+                <p class="mt-2 text-xs text-gray-500" data-pwa-status></p>
+            </div>
+            {% endif %}
+
             <p class="text-xs text-gray-400 mt-6">รีเฟรชหน้านี้เพื่อดูสถานะล่าสุด</p>
         </div>
 
         <p class="text-center text-xs text-gray-400 mt-4">นัดดี · NudDee</p>
     </div>
+    <script>
+      window.NUDDEE_MINI_APP = {
+        lineLiffId: {{ (messaging_config.line_liff_id if messaging_config else '')|tojson }},
+        checkinConfirm: {{ checkin_confirm|tojson }},
+        confirmationText: {{ ('เช็คอินสำเร็จที่ ' ~ service_point.name ~ ' คิวหมายเลข ' ~ entry.queue_number)|tojson }},
+        pwaSubscribeUrl: {{ pwa_subscribe_url|tojson }},
+        serviceWorkerUrl: {{ service_worker_url|tojson }},
+        vapidPublicKey: {{ (messaging_config.pwa_vapid_public_key if messaging_config and messaging_config.pwa_status == 'active' else '')|tojson }}
+      };
+    </script>
+    <script src="{{ url_for('static', filename='js/queue_mini_app.js') }}"></script>
 </body>
 </html>

--- a/hospital-booking/flask_app/app/templates/settings/messaging.html
+++ b/hospital-booking/flask_app/app/templates/settings/messaging.html
@@ -1,0 +1,181 @@
+{% extends "base.html" %}
+
+{% block title %}Messaging Channels - NudDee{% endblock %}
+
+{% block content %}
+<div class="max-w-5xl mx-auto py-8 px-4 sm:px-6 lg:px-8">
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold text-gray-900">Messaging Channels</h1>
+        <p class="mt-2 text-gray-600">ตั้งค่า LINE, Telegram และ PWA สำหรับคิวและการแจ้งเตือน</p>
+    </div>
+
+    <div class="space-y-8">
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <h2 class="text-xl font-semibold text-gray-900">LINE</h2>
+                    <p class="text-sm text-gray-500">Messaging API + LINE Login/LIFF สำหรับ webhook, Mini App และ push</p>
+                </div>
+                <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                    {{ config.line_status }}
+                </span>
+            </div>
+
+            <form method="POST" class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="section" value="line">
+
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Messaging channel ID</label>
+                    <input type="text" name="line_channel_id" value="{{ config.line_channel_id or '' }}"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">LINE Login channel ID</label>
+                    <input type="text" name="line_login_channel_id" value="{{ config.line_login_channel_id or '' }}"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">LIFF ID</label>
+                    <input type="text" name="line_liff_id" value="{{ config.line_liff_id or '' }}"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                    <select name="line_status" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                        {% for status in ['not_configured', 'active', 'disabled', 'error'] %}
+                        <option value="{{ status }}" {% if config.line_status == status %}selected{% endif %}>{{ status }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Channel secret</label>
+                    <input type="password" name="line_channel_secret"
+                           placeholder="เว้นว่างเพื่อคงค่าเดิม"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Channel access token</label>
+                    <input type="password" name="line_channel_token"
+                           placeholder="เว้นว่างเพื่อคงค่าเดิม"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                {% if config.line_last_error %}
+                <div class="md:col-span-2 text-sm text-red-600">ล่าสุด: {{ config.line_last_error }}</div>
+                {% endif %}
+                <div class="md:col-span-2 flex justify-end">
+                    <button type="submit" class="px-5 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700">
+                        บันทึก LINE
+                    </button>
+                </div>
+            </form>
+        </section>
+
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <h2 class="text-xl font-semibold text-gray-900">Telegram</h2>
+                    <p class="text-sm text-gray-500">วาง bot token เพื่อ verify getMe, setWebhook, Menu Button และ commands</p>
+                </div>
+                <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                    {{ config.telegram_status }}
+                </span>
+            </div>
+
+            <form method="POST" class="grid grid-cols-1 md:grid-cols-2 gap-5">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="section" value="telegram">
+
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Bot username</label>
+                    <input type="text" value="{{ config.telegram_bot_username or '' }}" disabled
+                           class="w-full px-3 py-2 border border-gray-200 rounded-lg bg-gray-50 text-gray-600">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Ownership</label>
+                    <select name="telegram_bot_ownership" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                        {% for ownership in ['tenant', 'saas'] %}
+                        <option value="{{ ownership }}" {% if config.telegram_bot_ownership == ownership %}selected{% endif %}>{{ ownership }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Mini App short name</label>
+                    <input type="text" name="telegram_mini_app_short_name" value="{{ config.telegram_mini_app_short_name or '' }}"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Status เมื่อไม่ใส่ token ใหม่</label>
+                    <select name="telegram_status" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                        {% for status in ['not_configured', 'active', 'disabled', 'error'] %}
+                        <option value="{{ status }}" {% if config.telegram_status == status %}selected{% endif %}>{{ status }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Bot token</label>
+                    <input type="password" name="telegram_bot_token"
+                           placeholder="ใส่เมื่อต้องการ provision/rotate token"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Web App URL override</label>
+                    <input type="url" name="telegram_web_app_url"
+                           placeholder="เว้นว่างเพื่อใช้ค่า default"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                {% if config.telegram_last_error %}
+                <div class="md:col-span-2 text-sm text-red-600">ล่าสุด: {{ config.telegram_last_error }}</div>
+                {% endif %}
+                <div class="md:col-span-2 flex justify-end">
+                    <button type="submit" class="px-5 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700">
+                        บันทึก / Provision Telegram
+                    </button>
+                </div>
+            </form>
+        </section>
+
+        <section class="bg-white rounded-lg shadow-sm border border-gray-200 p-6">
+            <div class="flex items-center justify-between mb-6">
+                <div>
+                    <h2 class="text-xl font-semibold text-gray-900">PWA Web Push</h2>
+                    <p class="text-sm text-gray-500">เก็บ VAPID key ต่อ tenant; private key จะถูก encrypt ก่อนบันทึก</p>
+                </div>
+                <span class="px-3 py-1 rounded-full text-xs font-medium bg-gray-100 text-gray-700">
+                    {{ config.pwa_status }}
+                </span>
+            </div>
+
+            <form method="POST" class="grid grid-cols-1 gap-5">
+                <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+                <input type="hidden" name="section" value="pwa">
+
+                <div class="max-w-sm">
+                    <label class="block text-sm font-medium text-gray-700 mb-1">Status</label>
+                    <select name="pwa_status" class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                        {% for status in ['disabled', 'active', 'error'] %}
+                        <option value="{{ status }}" {% if config.pwa_status == status %}selected{% endif %}>{{ status }}</option>
+                        {% endfor %}
+                    </select>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">VAPID public key</label>
+                    <textarea name="pwa_vapid_public_key" rows="2"
+                              class="w-full px-3 py-2 border border-gray-300 rounded-lg">{{ config.pwa_vapid_public_key or '' }}</textarea>
+                </div>
+                <div>
+                    <label class="block text-sm font-medium text-gray-700 mb-1">VAPID private key</label>
+                    <input type="password" name="pwa_vapid_private_key"
+                           placeholder="เว้นว่างเพื่อคงค่าเดิม"
+                           class="w-full px-3 py-2 border border-gray-300 rounded-lg">
+                </div>
+                <div class="flex justify-end">
+                    <button type="submit" class="px-5 py-2 bg-purple-600 text-white rounded-lg hover:bg-purple-700">
+                        บันทึก PWA
+                    </button>
+                </div>
+            </form>
+        </section>
+    </div>
+</div>
+{% endblock %}

--- a/hospital-booking/flask_app/app/webhook_routes.py
+++ b/hospital-booking/flask_app/app/webhook_routes.py
@@ -1,0 +1,207 @@
+"""Messaging webhooks and signed identity-link helpers (Phase 4.2 / 4.7).
+
+Webhook payloads can prove channel ownership, not patient identity by
+themselves. We only create channel_links when a signed webhook carries a
+canonical/linkable patient_ref produced by an authenticated app/link flow.
+"""
+
+from __future__ import annotations
+
+import re
+
+import requests
+from flask import Blueprint, abort, g, jsonify, request
+from sqlalchemy import text
+
+from shared_db import crypto, models
+from shared_db.database import bind_tenant
+
+from .services import messaging_links
+# P3 dedup: signature/initData verification + ref parsing live ONLY in
+# messaging_identity (single source of truth). Re-exported here so existing
+# wh.* references (routes + tests) keep working.
+from .services.messaging_identity import (  # noqa: F401
+    InitDataValidationError,
+    extract_patient_ref,
+    validate_telegram_init_data,
+    verify_line_signature,
+    verify_telegram_secret,
+)
+
+webhook_bp = Blueprint("webhooks", __name__, url_prefix="/webhooks")
+
+_START_SERVICE_POINT_RE = re.compile(r"^/start\s+sp_(\d+)$", re.IGNORECASE)
+
+
+def _get_config(db):
+    return db.query(models.MessagingConfig).order_by(models.MessagingConfig.id.asc()).first()
+
+
+def _resolve_tenant_context(db, tenant_key: str) -> dict | None:
+    row = db.execute(
+        text("""
+            SELECT schema_name, subdomain
+            FROM public.hospitals
+            WHERE schema_name = :tenant_key OR subdomain = :tenant_key
+            LIMIT 1
+        """),
+        {"tenant_key": tenant_key},
+    ).mappings().first()
+    return dict(row) if row else None
+
+
+def _bind_request_tenant(db, tenant_key: str) -> dict:
+    tenant = _resolve_tenant_context(db, tenant_key)
+    if not tenant:
+        abort(404)
+    schema_name = tenant["schema_name"]
+    bind_tenant(db, schema_name)
+    db.execute(text(f'SET search_path TO "{schema_name}", public'))
+    return tenant
+
+
+def _post_telegram_message(config, chat_id: str | int | None, text_message: str,
+                           http_client=requests, reply_markup: dict | None = None) -> bool:
+    if not chat_id or not getattr(config, "telegram_bot_token_enc", None):
+        return False
+    token = crypto.decrypt(config.telegram_bot_token_enc)
+    try:
+        response = http_client.post(
+            f"https://api.telegram.org/bot{token}/sendMessage",
+            json={
+                "chat_id": chat_id,
+                "text": text_message,
+                **({"reply_markup": reply_markup} if reply_markup else {}),
+            },
+            timeout=10,
+        )
+    except requests.RequestException:
+        return False
+    if response.status_code >= 400:
+        return False
+    try:
+        data = response.json()
+    except ValueError:
+        return False
+    return bool(data.get("ok"))
+
+
+def handle_line_events(db, payload: dict, config=None, http_client=requests) -> dict:
+    """Process a (signature-verified) LINE webhook.
+
+    SECURITY: a webhook proves channel ownership, NOT patient identity. We do NOT
+    create channel_links from a patient_ref embedded in user-sent message/postback
+    text — that ref is forgeable (anyone could send `patient_ref=patient:<id>` and
+    bind their LINE account to another patient's notifications). Identity linking
+    happens only via the verified Mini App flow (queue.channel_auth ->
+    messaging_identity.link_line_identity, which verifies a LINE-issued ID token).
+    """
+    return {"linked": 0, "skipped": len(payload.get("events", []))}
+
+
+def telegram_start_service_point_id(update: dict) -> int | None:
+    message = update.get("message") or update.get("edited_message") or {}
+    text_value = str(message.get("text") or "").strip()
+    match = _START_SERVICE_POINT_RE.match(text_value)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def _send_telegram_checkin_button(config, chat_id, service_point_id: int,
+                                  public_base_url: str | None,
+                                  subdomain: str | None,
+                                  http_client=requests) -> bool:
+    if not public_base_url:
+        return False
+    checkin_url = messaging_links.web_checkin_url(
+        public_base_url,
+        service_point_id,
+        subdomain=subdomain,
+    )
+    return _post_telegram_message(
+        config,
+        chat_id,
+        "กดปุ่มด้านล่างเพื่อเช็คอินกับ NudDee",
+        http_client=http_client,
+        reply_markup={
+            "inline_keyboard": [[{
+                "text": "เปิดหน้าเช็คอิน",
+                "web_app": {"url": checkin_url},
+            }]],
+        },
+    )
+
+
+def handle_telegram_update(db, update: dict, config=None, http_client=requests,
+                           public_base_url: str | None = None,
+                           subdomain: str | None = None) -> dict:
+    """Process a (secret-token-verified) Telegram webhook.
+
+    SECURITY: like LINE, we do NOT link an identity from a forgeable patient_ref in
+    free-text (e.g. `/start patient:<id>`). Identity linking happens only via the
+    verified Mini App flow (initData -> queue.channel_auth ->
+    messaging_identity.link_telegram_identity). The webhook only handles the
+    `/start sp_<id>` deep link by sending an inline web_app button to the check-in
+    page (which then opens the Mini App and links via the verified path).
+    """
+    config = config or _get_config(db)
+    message = update.get("message") or update.get("edited_message") or {}
+    chat = message.get("chat") or {}
+    chat_id = chat.get("id")
+
+    service_point_id = telegram_start_service_point_id(update)
+    if service_point_id is not None:
+        _send_telegram_checkin_button(
+            config,
+            chat_id,
+            service_point_id,
+            public_base_url,
+            subdomain,
+            http_client=http_client,
+        )
+        db.commit()
+        return {"linked": 0, "skipped": 1, "action": "checkin_button"}
+
+    db.commit()
+    return {"linked": 0, "skipped": 1}
+
+
+@webhook_bp.route("/line/<tenant_key>", methods=["POST"])
+def line_webhook(tenant_key):
+    _bind_request_tenant(g.db, tenant_key)
+    config = _get_config(g.db)
+    body = request.get_data()
+    secret = crypto.decrypt(config.line_channel_secret_enc) if config and config.line_channel_secret_enc else None
+    if not verify_line_signature(secret, body, request.headers.get("X-Line-Signature")):
+        abort(403)
+    payload = request.get_json(silent=True) or {}
+    return jsonify(handle_line_events(g.db, payload, config=config))
+
+
+@webhook_bp.route("/telegram/<tenant_key>", methods=["POST"])
+def telegram_webhook(tenant_key):
+    tenant = _bind_request_tenant(g.db, tenant_key)
+    config = _get_config(g.db)
+    if not verify_telegram_secret(config, request.headers.get("X-Telegram-Bot-Api-Secret-Token")):
+        abort(403)
+    payload = request.get_json(silent=True) or {}
+    return jsonify(handle_telegram_update(
+        g.db,
+        payload,
+        config=config,
+        public_base_url=request.url_root,
+        subdomain=tenant.get("subdomain"),
+    ))
+
+
+@webhook_bp.route("/telegram/<tenant_key>/init-data", methods=["POST"])
+def telegram_init_data(tenant_key):
+    _bind_request_tenant(g.db, tenant_key)
+    config = _get_config(g.db)
+    payload = request.get_json(silent=True) or {}
+    try:
+        data = validate_telegram_init_data(config, payload.get("initData") or "")
+    except InitDataValidationError as exc:
+        return jsonify({"valid": False, "error": str(exc)}), 403
+    return jsonify({"valid": True, "data": data})

--- a/hospital-booking/line_rich_menu.py
+++ b/hospital-booking/line_rich_menu.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""LINE Rich Menu setup (Phase 4.4) — one-time per tenant, needs a real LINE channel.
+
+There is no localhost path for this: the rich menu lives on LINE's servers and its
+buttons open your LIFF app (HTTPS). Run it once after the tenant's LINE channel is
+configured in /settings/messaging (line_status='active', channel token + line_liff_id
+saved):
+
+    PYTHONPATH=. python line_rich_menu.py --subdomain humnoi --image rich_menu.png
+
+The image is YOUR design. LINE spec: width 2500px, height 843 (compact, --size compact)
+or 1686 (full, --size full), PNG/JPEG, < 1 MB — the declared height must match the
+image. This script deletes any existing rich menus (so re-running doesn't pile them
+up), creates a 3-button menu (จองนัด / เช็คอิน / ดูคิว) that all open your LIFF app,
+uploads the image, and sets it as the default for every user.
+
+ponytail: setup tool, not in the test suite (needs live LINE creds). Edit _LABELS /
+_menu_body() to change the layout. No new dependency.
+"""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
+load_dotenv()  # before shared_db import (engine reads DATABASE_URL at import)
+
+import argparse
+import os
+import sys
+
+import requests
+from sqlalchemy import text
+
+from shared_db import crypto, models
+from shared_db.database import SessionLocal, bind_tenant
+
+_API = "https://api.line.me/v2/bot"
+_DATA_API = "https://api-data.line.me/v2/bot"
+_LABELS = ["จองนัด", "เช็คอิน", "ดูคิว"]
+_SIZES = {"compact": 843, "full": 1686}
+
+
+def _fail(message: str) -> None:
+    print(f"❌ {message}")
+    sys.exit(1)
+
+
+def _auth(token: str) -> dict:
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _load_tenant(subdomain: str) -> tuple[str, str, str]:
+    """Return (schema, decrypted LINE token, liff_id) for the tenant, or exit."""
+    db = SessionLocal()
+    try:
+        bind_tenant(db, None)
+        db.execute(text("SET search_path TO public"))
+        row = db.execute(
+            text("SELECT schema_name FROM public.hospitals "
+                 "WHERE subdomain = :s OR schema_name = :s LIMIT 1"),
+            {"s": subdomain},
+        ).first()
+        if not row:
+            _fail(f"ไม่พบ tenant: {subdomain}")
+        schema = row[0]
+        bind_tenant(db, schema)
+        db.execute(text(f'SET search_path TO "{schema}", public'))
+        cfg = db.query(models.MessagingConfig).order_by(models.MessagingConfig.id.asc()).first()
+        token_enc = getattr(cfg, "line_channel_token_enc", None)
+        liff_id = getattr(cfg, "line_liff_id", None)
+        if getattr(cfg, "line_status", None) != "active" or not token_enc:
+            _fail("tenant นี้ยังไม่ได้ตั้งค่า LINE ให้ active + ใส่ channel token (ที่ /settings/messaging)")
+        if not liff_id:
+            _fail("ยังไม่ได้ตั้ง line_liff_id — ปุ่มเมนูต้องเปิด LIFF (ตั้งที่ /settings/messaging)")
+        return schema, crypto.decrypt(token_enc), liff_id
+    finally:
+        bind_tenant(db, None)
+        try:
+            db.execute(text("SET search_path TO public"))
+            db.commit()
+        except Exception:
+            db.rollback()
+        db.close()
+
+
+def _menu_body(liff_url: str, height: int) -> dict:
+    third = 2500 // 3
+    areas = []
+    for i, label in enumerate(_LABELS):
+        x = i * third
+        width = (2500 - x) if i == len(_LABELS) - 1 else third  # last column eats the rounding
+        areas.append({
+            "bounds": {"x": x, "y": 0, "width": width, "height": height},
+            "action": {"type": "uri", "label": label, "uri": liff_url},
+        })
+    return {
+        "size": {"width": 2500, "height": height},
+        "selected": True,
+        "name": "NudDee menu",
+        "chatBarText": "เมนู NudDee",
+        "areas": areas,
+    }
+
+
+def _delete_existing(token: str) -> None:
+    resp = requests.get(f"{_API}/richmenu/list", headers=_auth(token), timeout=15)
+    if resp.status_code >= 400:
+        _fail(f"อ่านรายการ rich menu เดิมไม่ได้: {resp.status_code} {resp.text}")
+    for menu in resp.json().get("richmenus", []):
+        rid = menu.get("richMenuId")
+        requests.delete(f"{_API}/richmenu/{rid}", headers=_auth(token), timeout=15)
+        print(f"  - ลบ rich menu เดิม {rid}")
+
+
+def _create(token: str, body: dict) -> str:
+    resp = requests.post(f"{_API}/richmenu",
+                         headers={**_auth(token), "Content-Type": "application/json"},
+                         json=body, timeout=15)
+    if resp.status_code >= 400:
+        _fail(f"createRichMenu ล้มเหลว: {resp.status_code} {resp.text}")
+    return resp.json()["richMenuId"]
+
+
+def _upload_image(token: str, rid: str, image_path: str) -> None:
+    ctype = "image/jpeg" if image_path.lower().endswith((".jpg", ".jpeg")) else "image/png"
+    with open(image_path, "rb") as fh:
+        data = fh.read()
+    resp = requests.post(f"{_DATA_API}/richmenu/{rid}/content",
+                         headers={**_auth(token), "Content-Type": ctype},
+                         data=data, timeout=30)
+    if resp.status_code >= 400:
+        _fail(f"อัปโหลดรูปล้มเหลว: {resp.status_code} {resp.text}\n"
+              f"   LINE ต้องการ 2500×(843|1686) px, PNG/JPEG, <1MB และต้องตรงกับ --size")
+
+
+def _set_default(token: str, rid: str) -> None:
+    resp = requests.post(f"{_API}/user/all/richmenu/{rid}", headers=_auth(token), timeout=15)
+    if resp.status_code >= 400:
+        _fail(f"setDefaultRichMenu ล้มเหลว: {resp.status_code} {resp.text}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="ตั้งค่า LINE Rich Menu ให้ tenant")
+    parser.add_argument("--subdomain", required=True, help="subdomain หรือ schema ของ tenant")
+    parser.add_argument("--image", required=True, help="ไฟล์รูปเมนู (2500×843 หรือ 2500×1686)")
+    parser.add_argument("--size", choices=_SIZES, default="compact",
+                        help="compact=843px (default) / full=1686px — ต้องตรงกับความสูงรูป")
+    args = parser.parse_args()
+
+    if not os.path.isfile(args.image):
+        _fail(f"ไม่พบไฟล์รูป: {args.image}")
+
+    schema, token, liff_id = _load_tenant(args.subdomain)
+    liff_url = f"https://liff.line.me/{liff_id}"
+    print(f"tenant={schema}  liff={liff_url}  size={args.size}")
+
+    _delete_existing(token)
+    rid = _create(token, _menu_body(liff_url, _SIZES[args.size]))
+    print(f"  + สร้าง rich menu {rid}")
+    _upload_image(token, rid, args.image)
+    print("  + อัปโหลดรูปแล้ว")
+    _set_default(token, rid)
+    print(f"✅ ตั้ง rich menu เป็น default ให้ทุกคนแล้ว ({rid})")
+
+
+if __name__ == "__main__":
+    main()

--- a/hospital-booking/migrations/add_telegram_pool_structures.py
+++ b/hospital-booking/migrations/add_telegram_pool_structures.py
@@ -1,0 +1,71 @@
+"""
+Migration: Telegram control-plane account pool (Phase 4.6b / §4.11).
+
+Creates public-schema metadata tables for SaaS-managed Telegram bot accounts.
+Bot tokens are intentionally not stored here; tenant tokens remain encrypted in
+tenant.messaging_config.telegram_bot_token_enc.
+
+Usage:
+    python migrations/add_telegram_pool_structures.py
+"""
+
+import os
+import sys
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, text
+
+load_dotenv()
+
+DATABASE_URL = os.environ.get("DATABASE_URL")
+if not DATABASE_URL:
+    print("❌ DATABASE_URL ไม่ถูกตั้งใน .env")
+    sys.exit(1)
+
+
+DDL_STATEMENTS = [
+    """
+    CREATE TABLE IF NOT EXISTS public.saas_telegram_accounts (
+        id           SERIAL PRIMARY KEY,
+        label        VARCHAR(100) NOT NULL UNIQUE,
+        bot_capacity SMALLINT NOT NULL DEFAULT 20,
+        status       VARCHAR(10) NOT NULL DEFAULT 'active',
+        contact_note TEXT,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CHECK (bot_capacity > 0),
+        CHECK (status IN ('active', 'full', 'disabled'))
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS public.saas_telegram_bots (
+        id              SERIAL PRIMARY KEY,
+        saas_account_id INTEGER NOT NULL REFERENCES public.saas_telegram_accounts(id),
+        tenant_schema   VARCHAR(63) REFERENCES public.hospitals(schema_name),
+        bot_username    VARCHAR(100) NOT NULL UNIQUE,
+        status          VARCHAR(10) NOT NULL DEFAULT 'allocated',
+        created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+        updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+        CHECK (status IN ('allocated', 'spare', 'revoked'))
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_saas_tg_bots_account ON public.saas_telegram_bots (saas_account_id)",
+    "CREATE INDEX IF NOT EXISTS idx_saas_tg_bots_tenant ON public.saas_telegram_bots (tenant_schema)",
+    """
+    CREATE UNIQUE INDEX IF NOT EXISTS uq_saas_tg_bots_allocated_tenant
+        ON public.saas_telegram_bots (tenant_schema)
+        WHERE tenant_schema IS NOT NULL AND status = 'allocated'
+    """,
+]
+
+
+def main():
+    engine = create_engine(DATABASE_URL)
+    with engine.begin() as conn:
+        for statement in DDL_STATEMENTS:
+            conn.execute(text(statement))
+    print("✅ Telegram pool control-plane structures ready")
+
+
+if __name__ == "__main__":
+    main()

--- a/hospital-booking/requirements.txt
+++ b/hospital-booking/requirements.txt
@@ -30,6 +30,10 @@ pydantic==2.12.5
 stripe==6.6.0
 requests==2.32.5
 
+# Web Push (PWA queue notifications — notify_service.py; sender fail-closed if absent)
+# pulls py-vapid (needs cryptography>=46, satisfied by the pin above)
+pywebpush==2.3.0
+
 # Auth / OTP
 pyotp==2.9.0
 

--- a/hospital-booking/shared_db/models.py
+++ b/hospital-booking/shared_db/models.py
@@ -98,6 +98,46 @@ class User(PublicBase):
     def check_password(self, password):
         return check_password_hash(self.password_hash, password)
 
+
+class SaasTelegramAccount(PublicBase):
+    """Control-plane registry for SaaS-managed Telegram accounts (no credentials)."""
+    __tablename__ = 'saas_telegram_accounts'
+    __table_args__ = (
+        {'schema': 'public'},
+    )
+
+    id = Column(Integer, primary_key=True)
+    label = Column(String(100), nullable=False, unique=True)
+    bot_capacity = Column(SmallInteger, nullable=False, server_default=text('20'))
+    status = Column(String(10), nullable=False, server_default=text("'active'"))  # active | full | disabled
+    contact_note = Column(Text)
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    bots = relationship("SaasTelegramBot", back_populates="account")
+
+
+class SaasTelegramBot(PublicBase):
+    """Bot allocation metadata. Bot tokens live encrypted in tenant messaging_config."""
+    __tablename__ = 'saas_telegram_bots'
+    __table_args__ = (
+        Index('idx_saas_tg_bots_account', 'saas_account_id'),
+        Index('idx_saas_tg_bots_tenant', 'tenant_schema'),
+        Index('uq_saas_tg_bots_allocated_tenant', 'tenant_schema', unique=True,
+              postgresql_where=text("tenant_schema IS NOT NULL AND status = 'allocated'")),
+        {'schema': 'public'},
+    )
+
+    id = Column(Integer, primary_key=True)
+    saas_account_id = Column(Integer, ForeignKey('public.saas_telegram_accounts.id'), nullable=False)
+    tenant_schema = Column(String(63), ForeignKey('public.hospitals.schema_name'))
+    bot_username = Column(String(100), nullable=False, unique=True)
+    status = Column(String(10), nullable=False, server_default=text("'allocated'"))  # allocated | spare | revoked
+    created_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), nullable=False, server_default=func.now(), onupdate=func.now())
+
+    account = relationship("SaasTelegramAccount", back_populates="bots")
+
 # --- Tenant Specific Models ---
 
 class AvailabilityTemplate(TenantBase):

--- a/hospital-booking/telegram_poller.py
+++ b/hospital-booking/telegram_poller.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Telegram long-polling consumer — LOCAL DEV ONLY (no public HTTPS needed).
+
+Two delivery modes for the same bot:
+  • webhook  (production)  — provision_telegram_bot() calls setWebhook; Telegram
+                             POSTs updates to https://<tenant>/webhooks/telegram/<key>.
+  • polling  (this script) — getUpdates long-poll over plain http, for testing on
+                             localhost where you have no public HTTPS endpoint.
+
+getUpdates and webhooks are mutually exclusive, so this script first deletes the
+webhook for each bot, then long-polls and feeds every update through the SAME
+handler the webhook uses (webhook_routes.handle_telegram_update). Switch back to
+webhook for deploy by re-saving the Telegram settings (re-provision → setWebhook).
+
+Run from the repo root (loads .env, needs MESSAGING_ENCRYPTION_KEYS for the token):
+
+    PYTHONPATH=. python telegram_poller.py
+
+What works over plain http: the bot RECEIVING commands and replying — send
+`/start sp_<id>` to your bot and it replies with the check-in button. What still
+needs HTTPS (use a tunnel like cloudflared): TAPPING a Telegram web_app button to
+open the Mini App, and LIFF / identity linking.
+
+ponytail: dev tool. Sequential long-poll, in-memory offset per run, no DB column,
+no new dependency. Sequential across tenants is fine for 1–2 dev bots; run one
+poller per bot (or thread them) only if you ever test many tenants at once.
+"""
+
+from __future__ import annotations
+
+from dotenv import load_dotenv
+
+load_dotenv()  # must precede shared_db import (engine reads DATABASE_URL at import)
+
+import os
+import time
+
+import requests
+from sqlalchemy import text
+
+from shared_db import crypto
+from shared_db.database import SessionLocal, bind_tenant
+from shared_db.models import Hospital, HospitalStatus
+from flask_app.app.webhook_routes import handle_telegram_update, _get_config
+
+POLL_TIMEOUT = int(os.environ.get("TELEGRAM_POLL_TIMEOUT", "20"))           # long-poll seconds
+PUBLIC_BASE_URL = os.environ.get("PUBLIC_BASE_URL", "http://localhost:5001/")
+_API = "https://api.telegram.org/bot{token}/{method}"
+
+
+def _reset_close(db) -> None:
+    """Return the connection to the pool on a clean public search_path."""
+    bind_tenant(db, None)
+    try:
+        db.execute(text("SET search_path TO public"))
+        db.commit()
+    except Exception:
+        db.rollback()
+    db.close()
+
+
+def _telegram_tenants() -> list[tuple[str, str, str]]:
+    """Return (schema, subdomain, decrypted_token) for tenants with Telegram active."""
+    out: list[tuple[str, str, str]] = []
+    db = SessionLocal()
+    try:
+        bind_tenant(db, None)
+        db.execute(text("SET search_path TO public"))
+        rows = [(h.schema_name, h.subdomain)
+                for h in db.query(Hospital)
+                .filter(Hospital.status == HospitalStatus.ACTIVE).all()]
+    finally:
+        _reset_close(db)
+
+    for schema, subdomain in rows:
+        tdb = SessionLocal()
+        try:
+            bind_tenant(tdb, schema)
+            tdb.execute(text(f'SET search_path TO "{schema}", public'))
+            cfg = _get_config(tdb)
+            token_enc = getattr(cfg, "telegram_bot_token_enc", None)
+            if token_enc and getattr(cfg, "telegram_status", None) == "active":
+                out.append((schema, subdomain, crypto.decrypt(token_enc)))
+        finally:
+            _reset_close(tdb)
+    return out
+
+
+def _delete_webhook(token: str) -> None:
+    # drop_pending_updates=False so messages sent while you were on webhook still arrive
+    requests.post(_API.format(token=token, method="deleteWebhook"),
+                  json={"drop_pending_updates": False}, timeout=15)
+
+
+def _get_updates(token: str, offset: int | None) -> list[dict]:
+    resp = requests.post(
+        _API.format(token=token, method="getUpdates"),
+        json={"offset": offset, "timeout": POLL_TIMEOUT},
+        timeout=POLL_TIMEOUT + 10,
+    )
+    data = resp.json()
+    if not data.get("ok"):
+        raise RuntimeError(data.get("description") or "getUpdates failed")
+    return data.get("result", [])
+
+
+def _process(schema: str, subdomain: str, update: dict) -> None:
+    db = SessionLocal()
+    try:
+        bind_tenant(db, schema)
+        db.execute(text(f'SET search_path TO "{schema}", public'))
+        handle_telegram_update(db, update, config=_get_config(db),
+                               public_base_url=PUBLIC_BASE_URL, subdomain=subdomain)
+    except Exception as exc:  # never let one bad update kill the loop
+        print(f"[telegram-poll] {schema} update {update.get('update_id')} FAILED: {exc}")
+        db.rollback()
+    finally:
+        _reset_close(db)
+
+
+def main() -> None:
+    tenants = _telegram_tenants()
+    if not tenants:
+        print("No tenant has Telegram active (telegram_status='active' + a saved token).\n"
+              "Provision a bot in /settings/messaging first, then re-run.")
+        return
+
+    print("⚠️  Switching these bots to POLLING — this deletes their webhook. "
+          "Re-provision (re-save Telegram settings) to restore webhook for deploy.")
+    for schema, subdomain, token in tenants:
+        _delete_webhook(token)
+        print(f"[telegram-poll] polling {schema} (subdomain={subdomain})")
+    print(f"[telegram-poll] long-poll timeout={POLL_TIMEOUT}s, base={PUBLIC_BASE_URL}. Ctrl+C to stop.")
+
+    offsets: dict[str, int | None] = {schema: None for schema, _, _ in tenants}
+    while True:
+        for schema, subdomain, token in tenants:
+            try:
+                updates = _get_updates(token, offsets[schema])
+            except Exception as exc:
+                print(f"[telegram-poll] {schema} getUpdates error: {exc}")
+                time.sleep(3)
+                continue
+            for upd in updates:
+                _process(schema, subdomain, upd)
+                offsets[schema] = upd["update_id"] + 1
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except KeyboardInterrupt:
+        print("\n[telegram-poll] stopped.")

--- a/hospital-booking/tests/test_checkin_rate_limit.py
+++ b/hospital-booking/tests/test_checkin_rate_limit.py
@@ -1,0 +1,26 @@
+"""Per-IP fixed-window throttle for the public (no-auth) check-in POST."""
+
+from flask_app.app import queue_routes as qr
+
+
+class _FakeRedis:
+    def __init__(self):
+        self.counts = {}
+        self.expires = {}
+
+    def incr(self, key):
+        self.counts[key] = self.counts.get(key, 0) + 1
+        return self.counts[key]
+
+    def expire(self, key, window):
+        self.expires[key] = window
+
+
+def test_rate_limited_flips_after_limit():
+    r = _FakeRedis()
+    # limit=3 → the 4th and 5th hits in the window are throttled
+    results = [qr._rate_limited(r, 'checkin_rl:1:1.2.3.4', 3, 60) for _ in range(5)]
+    assert results == [False, False, False, True, True]
+    # TTL is set exactly once (on the first hit) — not reset every incr, or the
+    # window would never roll over.
+    assert r.expires == {'checkin_rl:1:1.2.3.4': 60}

--- a/hospital-booking/tests/test_line_quota.py
+++ b/hospital-booking/tests/test_line_quota.py
@@ -1,0 +1,47 @@
+"""LINE push-quota remaining (Phase 5.3, second half)."""
+
+from flask_app.app.services import analytics_service as a
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._payload = payload
+        self.status_code = status
+
+    def json(self):
+        return self._payload
+
+
+class _FakeLine:
+    def __init__(self, quota, consumption):
+        self._quota = quota
+        self._consumption = consumption
+
+    def get(self, url, **_):
+        return _Resp(self._quota) if url.endswith("/quota") else _Resp(self._consumption)
+
+
+def test_line_quota_limited_computes_remaining():
+    client = _FakeLine({"type": "limited", "value": 1000}, {"totalUsage": 300})
+    assert a._line_quota_from_api("tok", client) == {
+        "type": "limited", "limit": 1000, "used": 300, "remaining": 700,
+    }
+
+
+def test_line_quota_unlimited_plan_has_no_counts():
+    client = _FakeLine({"type": "none"}, {})
+    result = a._line_quota_from_api("tok", client)
+    assert result["type"] == "none" and result["remaining"] is None
+
+
+def test_line_quota_remaining_never_negative():
+    client = _FakeLine({"type": "limited", "value": 500}, {"totalUsage": 900})
+    assert a._line_quota_from_api("tok", client)["remaining"] == 0
+
+
+def test_line_quota_http_error_is_unavailable():
+    class _Err:
+        def get(self, url, **_):
+            return _Resp({"message": "Authentication failed"}, status=401)
+
+    assert a._line_quota_from_api("tok", _Err()) is None

--- a/hospital-booking/tests/test_messaging_identity.py
+++ b/hospital-booking/tests/test_messaging_identity.py
@@ -1,0 +1,173 @@
+import datetime
+import hashlib
+import hmac
+import json
+from urllib.parse import urlencode
+
+import pytest
+
+from flask_app.app.services import messaging_identity as mi
+from shared_db import crypto, models
+
+
+@pytest.fixture()
+def messaging_key(monkeypatch):
+    monkeypatch.setenv(crypto.ENV_KEY, crypto.generate_key())
+
+
+class FakeLineVerifyHttp:
+    def __init__(self, claims, status_code=200):
+        self.claims = claims
+        self.status_code = status_code
+        self.calls = []
+
+    def post(self, url, data, timeout):
+        self.calls.append({"url": url, "data": data, "timeout": timeout})
+        claims = self.claims
+        status_code = self.status_code
+        return type("Response", (), {
+            "status_code": status_code,
+            "json": lambda self: claims,
+        })()
+
+
+def _init_data(token, params):
+    data_check_string = "\n".join(f"{key}={params[key]}" for key in sorted(params))
+    secret_key = hmac.new(b"WebAppData", token.encode("utf-8"), hashlib.sha256).digest()
+    supplied_hash = hmac.new(secret_key, data_check_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    return urlencode({**params, "hash": supplied_hash})
+
+
+def _appointment(db):
+    patient = models.Patient(name="Test Patient", phone_number="0812345678")
+    db.add(patient)
+    db.flush()
+    appt = models.Appointment(
+        patient_id=patient.id,
+        booking_reference="VN-AUTH1",
+        start_time=datetime.datetime(2026, 6, 17, 9, 0),
+        end_time=datetime.datetime(2026, 6, 17, 9, 30),
+    )
+    db.add(appt)
+    db.commit()
+    return patient, appt
+
+
+def test_line_id_token_links_verified_user_to_booking_patient(db, messaging_key):
+    patient, _ = _appointment(db)
+    cfg = models.MessagingConfig(line_login_channel_id="line-login-123")
+    db.add(cfg)
+    db.commit()
+    http = FakeLineVerifyHttp({
+        "aud": "line-login-123",
+        "sub": "UlineUser",
+        "name": "LINE User",
+    })
+
+    link = mi.link_line_identity(
+        db,
+        config=cfg,
+        id_token="opaque-id-token",
+        booking_reference="VN-AUTH1",
+        http_client=http,
+    )
+
+    assert http.calls[0]["url"] == "https://api.line.me/oauth2/v2.1/verify"
+    assert http.calls[0]["data"] == {
+        "id_token": "opaque-id-token",
+        "client_id": "line-login-123",
+    }
+    assert link.patient_ref == f"patient:{patient.id}"
+    assert link.channel == "line"
+    assert link.external_id == "UlineUser"
+    assert link.raw_profile == {"source": "liff_id_token", "name": "LINE User"}
+
+
+def test_line_id_token_audience_mismatch_does_not_link(db, messaging_key):
+    _appointment(db)
+    cfg = models.MessagingConfig(line_login_channel_id="line-login-123")
+    db.add(cfg)
+    db.commit()
+    http = FakeLineVerifyHttp({"aud": "wrong-channel", "sub": "UlineUser"})
+
+    with pytest.raises(mi.LineIdTokenError, match="audience_mismatch"):
+        mi.link_line_identity(
+            db,
+            config=cfg,
+            id_token="opaque-id-token",
+            booking_reference="VN-AUTH1",
+            http_client=http,
+        )
+
+    db.rollback()
+    assert db.query(models.ChannelLink).count() == 0
+
+
+def test_telegram_init_data_links_verified_user_to_booking_patient(db, messaging_key):
+    patient, _ = _appointment(db)
+    token = "123456:telegram-token"
+    cfg = models.MessagingConfig(
+        telegram_bot_token_enc=crypto.encrypt(token),
+        telegram_status="active",
+    )
+    db.add(cfg)
+    db.commit()
+    now = int(datetime.datetime(2026, 6, 17, tzinfo=datetime.timezone.utc).timestamp())
+    user = json.dumps({"id": 9001, "username": "nuddee_user"}, separators=(",", ":"))
+    init_data = _init_data(token, {
+        "auth_date": str(now),
+        "user": user,
+    })
+
+    link = mi.link_telegram_identity(
+        db,
+        config=cfg,
+        init_data=init_data,
+        booking_reference="VN-AUTH1",
+        now=now,
+    )
+
+    assert link.patient_ref == f"patient:{patient.id}"
+    assert link.channel == "telegram"
+    assert link.external_id == "9001"
+    assert link.raw_profile == {
+        "source": "telegram_init_data",
+        "username": "nuddee_user",
+    }
+
+
+def test_telegram_init_data_phone_only_rejected_without_booking(db, messaging_key):
+    """SECURITY: a self-asserted phone (no booking_reference) must NOT establish identity."""
+    token = "123456:telegram-token"
+    cfg = models.MessagingConfig(
+        telegram_bot_token_enc=crypto.encrypt(token),
+        telegram_status="active",
+    )
+    db.add(cfg)
+    db.commit()
+    now = int(datetime.datetime(2026, 6, 17, tzinfo=datetime.timezone.utc).timestamp())
+    user = json.dumps({"id": 9001, "username": "nuddee_user"}, separators=(",", ":"))
+    init_data = _init_data(token, {"auth_date": str(now), "user": user})
+
+    with pytest.raises(mi.ChannelIdentityError, match="booking_reference_required"):
+        mi.link_telegram_identity(db, config=cfg, init_data=init_data,
+                                  patient_phone="081-234-5678", now=now)
+    db.rollback()
+    assert db.query(models.ChannelLink).count() == 0
+
+
+def test_pwa_subscription_links_with_booking_reference(db):
+    patient, _ = _appointment(db)
+    link = mi.link_pwa_subscription(
+        db,
+        subscription={"endpoint": "https://push.example/sub/1", "keys": {"p256dh": "k"}},
+        booking_reference="VN-AUTH1",
+    )
+
+    assert link.patient_ref == f"patient:{patient.id}"
+    assert link.channel == "pwa"
+    assert link.external_id == "https://push.example/sub/1"
+    assert link.raw_profile == {"endpoint": "https://push.example/sub/1", "keys": {"p256dh": "k"}}
+
+    with pytest.raises(mi.ChannelIdentityError, match="pwa_endpoint_missing"):
+        mi.link_pwa_subscription(db, subscription={}, booking_reference="VN-AUTH1")

--- a/hospital-booking/tests/test_messaging_links.py
+++ b/hospital-booking/tests/test_messaging_links.py
@@ -1,0 +1,40 @@
+from shared_db import models
+from flask_app.app.services import messaging_links
+
+
+def test_build_checkin_links_includes_web_and_configured_channels():
+    cfg = models.MessagingConfig(
+        line_liff_id="2000000000-AbCdEf",
+        telegram_bot_username="nuddee_test_bot",
+        telegram_mini_app_short_name="checkin",
+    )
+
+    links = messaging_links.build_checkin_links(
+        cfg,
+        "https://humnoi.example.com/",
+        12,
+        subdomain="humnoi",
+    )
+
+    assert links == {
+        "web": "https://humnoi.example.com/queue/checkin/12?subdomain=humnoi",
+        "line_liff": (
+            "https://liff.line.me/2000000000-AbCdEf?service_point_id=12&"
+            "checkin_url=https%3A%2F%2Fhumnoi.example.com%2Fqueue%2Fcheckin%2F12%3Fsubdomain%3Dhumnoi"
+        ),
+        "telegram": "https://t.me/nuddee_test_bot/checkin?startapp=sp_12",
+    }
+
+
+def test_telegram_checkin_url_falls_back_to_bot_deep_link_without_short_name():
+    cfg = models.MessagingConfig(telegram_bot_username="nuddee_test_bot")
+
+    assert messaging_links.telegram_checkin_url(cfg, 5) == (
+        "https://t.me/nuddee_test_bot?start=sp_5"
+    )
+
+
+def test_unconfigured_channel_links_are_omitted():
+    links = messaging_links.build_checkin_links(None, "https://example.com", 7)
+
+    assert links == {"web": "https://example.com/queue/checkin/7"}

--- a/hospital-booking/tests/test_notify_service.py
+++ b/hospital-booking/tests/test_notify_service.py
@@ -3,6 +3,9 @@ import threading
 import time
 from collections import Counter
 
+import pytest
+
+from shared_db import crypto
 from shared_db import models
 from flask_app.app.services import notify_service as ns
 
@@ -61,6 +64,11 @@ def _queue_entry(db, service_point):
     db.commit()
     db.refresh(entry)
     return entry
+
+
+@pytest.fixture()
+def messaging_key(monkeypatch):
+    monkeypatch.setenv(crypto.ENV_KEY, crypto.generate_key())
 
 
 def test_notify_prefers_telegram_free_before_line_push(db, service_point):
@@ -174,6 +182,47 @@ def test_notify_falls_back_after_failed_channel(db):
         ('telegram', 'failed', 0),
         ('pwa', 'sent', 0),
     ]
+
+
+def test_notify_default_pwa_sender_uses_webpush(db, messaging_key, monkeypatch):
+    cfg = models.MessagingConfig(
+        pwa_status='active',
+        pwa_vapid_public_key='public-key',
+        pwa_vapid_private_key_enc=crypto.encrypt('private-key'),
+        channel_priority=['pwa'],
+    )
+    db.add(cfg)
+    db.commit()
+    link = models.ChannelLink(
+        patient_ref='patient:10',
+        channel='pwa',
+        external_id='https://push.example/sub/10',
+        is_active=True,
+        raw_profile={'endpoint': 'https://push.example/sub/10', 'keys': {'p256dh': 'k', 'auth': 'a'}},
+    )
+    db.add(link)
+    db.commit()
+    calls = []
+
+    def fake_webpush(**kwargs):
+        calls.append(kwargs)
+
+    monkeypatch.setattr(ns, '_webpush', fake_webpush)
+
+    result = ns.notify(
+        db,
+        'patient:10',
+        'queue_turn',
+        'critical',
+        context={'queue_number': 10, 'url': '/queue/ticket/10'},
+        now=DT(2026, 6, 15, 9, 0),
+    )
+
+    assert result == ns.NotificationResult('pwa', 0, 'sent')
+    assert calls[0]['subscription_info'] == link.raw_profile
+    assert calls[0]['vapid_private_key'] == 'private-key'
+    assert calls[0]['vapid_claims'] == {'sub': 'mailto:noreply@nuddee.com'}
+    assert '"url": "/queue/ticket/10"' in calls[0]['data']
 
 
 def test_notify_uses_only_active_channel_statuses(db):

--- a/hospital-booking/tests/test_queue_notifications.py
+++ b/hospital-booking/tests/test_queue_notifications.py
@@ -1,4 +1,5 @@
 import datetime
+import types
 
 import pytest
 
@@ -95,6 +96,24 @@ def test_enqueue_queue_event_uses_worker_dotted_path():
         {"queue_number": 9},
     )
     assert kwargs == {"job_timeout": "2m"}
+
+
+def test_enqueue_queue_turn_threads_pwa_url(monkeypatch):
+    # The PWA push click target must ride along in the context, or _send_pwa
+    # falls back to "/" in the real queued path (the sender test injects it manually).
+    fake = FakeQueue()
+    monkeypatch.setattr(qn.redis_manager, "get_queue", lambda name: fake)
+    entry = types.SimpleNamespace(
+        id=7, queue_number=7, service_point_id=1, session_id=None,
+        session_date=datetime.date(2026, 6, 16), status="called",
+    )
+
+    qn.enqueue_queue_turn("tenant_humnoi", entry, url="https://h.example/queue/ticket/tok")
+    assert fake.calls[0][0][5]["url"] == "https://h.example/queue/ticket/tok"
+
+    fake.calls.clear()
+    qn.enqueue_queue_turn("tenant_humnoi", entry)          # no url → key absent (sender uses "/")
+    assert "url" not in fake.calls[0][0][5]
 
 
 def test_notify_queue_event_job_sends_queue_turn_via_free_telegram(

--- a/hospital-booking/tests/test_telegram_pool.py
+++ b/hospital-booking/tests/test_telegram_pool.py
@@ -1,0 +1,164 @@
+import pytest
+from sqlalchemy import text
+
+from flask_app.app.services import telegram_pool
+from shared_db import models
+
+
+@pytest.fixture()
+def telegram_pool_public(engine, db):
+    with engine.begin() as conn:
+        models.PublicBase.metadata.create_all(bind=conn)
+
+    def cleanup():
+        (db.query(models.SaasTelegramBot)
+         .filter(models.SaasTelegramBot.tenant_schema.like("pool_test_%"))
+         .delete(synchronize_session=False))
+        (db.query(models.SaasTelegramBot)
+         .filter(models.SaasTelegramBot.bot_username.like("pool_test_%"))
+         .delete(synchronize_session=False))
+        (db.query(models.SaasTelegramAccount)
+         .filter(models.SaasTelegramAccount.label.like("pool_test_%"))
+         .delete(synchronize_session=False))
+        (db.query(models.Hospital)
+         .filter(models.Hospital.schema_name.like("pool_test_%"))
+         .delete(synchronize_session=False))
+        schemas = (db.execute(text("""
+            SELECT schema_name
+            FROM information_schema.schemata
+            WHERE schema_name LIKE 'pool_test_%'
+        """)).scalars().all())
+        for schema in schemas:
+            db.execute(text(f'DROP SCHEMA IF EXISTS "{schema}" CASCADE'))
+        db.commit()
+
+    cleanup()
+    yield
+    cleanup()
+
+
+def _hospital(db, suffix):
+    schema_name = f"pool_test_{suffix}"
+    db.execute(text("""
+        INSERT INTO public.hospitals (name, subdomain, schema_name, status)
+        VALUES (:name, :subdomain, :schema_name, 'active')
+        ON CONFLICT (schema_name) DO UPDATE
+        SET name = EXCLUDED.name,
+            subdomain = EXCLUDED.subdomain,
+            status = EXCLUDED.status
+    """), {
+        "name": f"Pool Test {suffix}",
+        "subdomain": f"pool-test-{suffix}",
+        "schema_name": schema_name,
+    })
+    db.commit()
+    return schema_name
+
+
+def test_allocate_account_skips_accounts_at_capacity(db, telegram_pool_public):
+    h1 = _hospital(db, "one")
+    acc1 = models.SaasTelegramAccount(label="pool_test_1", bot_capacity=1, status="active")
+    acc2 = models.SaasTelegramAccount(label="pool_test_2", bot_capacity=2, status="active")
+    db.add_all([acc1, acc2])
+    db.commit()
+    db.add(models.SaasTelegramBot(
+        saas_account_id=acc1.id,
+        tenant_schema=h1,
+        bot_username="pool_test_one_bot",
+        status="allocated",
+    ))
+    db.commit()
+
+    selected = telegram_pool.allocate_account(db)
+
+    assert selected.id == acc2.id
+
+
+def test_register_bot_rechecks_capacity_and_marks_full(db, telegram_pool_public):
+    hospital = _hospital(db, "two")
+    acc = models.SaasTelegramAccount(label="pool_test_single", bot_capacity=1, status="active")
+    db.add(acc)
+    db.commit()
+
+    bot = telegram_pool.register_bot(
+        db,
+        saas_account_id=acc.id,
+        tenant_schema=hospital,
+        bot_username="@pool_test_two_bot",
+    )
+
+    assert bot.tenant_schema == "pool_test_two"
+    assert bot.bot_username == "pool_test_two_bot"
+    assert bot.status == "allocated"
+    db.refresh(acc)
+    assert acc.status == "full"
+    assert not hasattr(bot, "token")
+
+
+def test_register_bot_is_idempotent_for_same_allocation(db, telegram_pool_public):
+    hospital = _hospital(db, "three")
+    acc = models.SaasTelegramAccount(label="pool_test_idempotent", bot_capacity=2, status="active")
+    db.add(acc)
+    db.commit()
+
+    first = telegram_pool.register_bot(
+        db,
+        saas_account_id=acc.id,
+        tenant_schema=hospital,
+        bot_username="pool_test_three_bot",
+    )
+    second = telegram_pool.register_bot(
+        db,
+        saas_account_id=acc.id,
+        tenant_schema=hospital,
+        bot_username="pool_test_three_bot",
+    )
+
+    assert second.id == first.id
+    assert (db.query(models.SaasTelegramBot)
+            .filter_by(tenant_schema=hospital, status="allocated")
+            .count()) == 1
+
+
+def test_register_bot_idempotent_after_account_marked_full(db, telegram_pool_public):
+    # capacity=1: the first allocation fills the account and marks it "full".
+    # Retrying the SAME allocation must still return it, not raise PoolExhausted.
+    hospital = _hospital(db, "six")
+    acc = models.SaasTelegramAccount(label="pool_test_full_retry", bot_capacity=1, status="active")
+    db.add(acc)
+    db.commit()
+
+    first = telegram_pool.register_bot(
+        db, saas_account_id=acc.id, tenant_schema=hospital,
+        bot_username="pool_test_six_bot",
+    )
+    db.refresh(acc)
+    assert acc.status == "full"
+
+    second = telegram_pool.register_bot(
+        db, saas_account_id=acc.id, tenant_schema=hospital,
+        bot_username="pool_test_six_bot",
+    )
+    assert second.id == first.id
+
+
+def test_register_bot_rejects_over_capacity_account(db, telegram_pool_public):
+    h1 = _hospital(db, "four")
+    h2 = _hospital(db, "five")
+    acc = models.SaasTelegramAccount(label="pool_test_full", bot_capacity=1, status="active")
+    db.add(acc)
+    db.commit()
+    telegram_pool.register_bot(
+        db,
+        saas_account_id=acc.id,
+        tenant_schema=h1,
+        bot_username="pool_test_four_bot",
+    )
+
+    with pytest.raises(telegram_pool.PoolExhausted):
+        telegram_pool.register_bot(
+            db,
+            saas_account_id=acc.id,
+            tenant_schema=h2,
+            bot_username="pool_test_five_bot",
+        )

--- a/hospital-booking/tests/test_ticket_token.py
+++ b/hospital-booking/tests/test_ticket_token.py
@@ -1,0 +1,20 @@
+"""Signed, tenant-bound ticket tokens replace the enumerable numeric entry_id."""
+
+from flask_app.app import queue_routes as qr
+
+
+def test_ticket_token_roundtrip_and_tenant_binding():
+    token = qr.make_ticket_token(42, 'tenant_humnoi')
+
+    # valid token for the same tenant resolves back to the entry id
+    assert qr.read_ticket_token(token, 'tenant_humnoi') == 42
+
+    # a token minted for another tenant is rejected (no cross-tenant reuse)
+    assert qr.read_ticket_token(token, 'tenant_other') is None
+
+    # tampered / garbage tokens are rejected, never raise
+    assert qr.read_ticket_token(token + 'x', 'tenant_humnoi') is None
+    assert qr.read_ticket_token('garbage', 'tenant_humnoi') is None
+
+    # tokens are not the bare id (enumeration is the whole point of this)
+    assert str(42) not in token

--- a/hospital-booking/tests/test_webhook_routes.py
+++ b/hospital-booking/tests/test_webhook_routes.py
@@ -1,0 +1,198 @@
+import base64
+import datetime
+import hashlib
+import hmac
+import json
+from urllib.parse import urlencode
+
+import pytest
+
+from shared_db import crypto, models
+from flask_app.app import webhook_routes as wh
+
+
+@pytest.fixture()
+def messaging_key(monkeypatch):
+    monkeypatch.setenv(crypto.ENV_KEY, crypto.generate_key())
+
+
+def _config(db, *, line_secret="line-secret", telegram_secret="telegram-secret",
+            telegram_token="123456:telegram-token"):
+    cfg = models.MessagingConfig(
+        line_channel_secret_enc=crypto.encrypt(line_secret),
+        line_status="active",
+        telegram_webhook_secret_enc=crypto.encrypt(telegram_secret),
+        telegram_bot_token_enc=crypto.encrypt(telegram_token),
+        telegram_status="active",
+    )
+    db.add(cfg)
+    db.commit()
+    db.refresh(cfg)
+    return cfg
+
+
+def _line_signature(secret, body):
+    digest = hmac.new(secret.encode("utf-8"), body, hashlib.sha256).digest()
+    return base64.b64encode(digest).decode("ascii")
+
+
+def _init_data(token, params):
+    data_check_string = "\n".join(f"{key}={params[key]}" for key in sorted(params))
+    secret_key = hmac.new(b"WebAppData", token.encode("utf-8"), hashlib.sha256).digest()
+    supplied_hash = hmac.new(secret_key, data_check_string.encode("utf-8"), hashlib.sha256).hexdigest()
+    return urlencode({**params, "hash": supplied_hash})
+
+
+class FakeTelegramReplyHttp:
+    def __init__(self):
+        self.calls = []
+
+    def post(self, url, json, timeout):
+        self.calls.append({"url": url, "json": json, "timeout": timeout})
+        return type("Response", (), {"status_code": 200, "json": lambda self: {"ok": True}})()
+
+
+def test_line_signature_verify_accepts_only_matching_signature():
+    body = b'{"events":[]}'
+    sig = _line_signature("line-secret", body)
+
+    assert wh.verify_line_signature("line-secret", body, sig) is True
+    assert wh.verify_line_signature("line-secret", body, "bad") is False
+    assert wh.verify_line_signature(None, body, sig) is False
+
+
+def test_line_webhook_ignores_forgeable_free_text_ref(db, messaging_key):
+    """SECURITY: a patient_ref in user-sent message text must NOT create a link.
+
+    Anyone could send `patient_ref=patient:42` to the OA and bind their LINE
+    account to another patient's notifications — webhook linking is removed;
+    identity linking is only via the verified Mini App (channel-auth/LIFF).
+    """
+    cfg = _config(db)
+    payload = {
+        "events": [{
+            "type": "message",
+            "source": {"type": "user", "userId": "Uline123"},
+            "message": {"type": "text", "text": "patient_ref=patient:42"},
+        }]
+    }
+
+    result = wh.handle_line_events(db, payload, config=cfg)
+
+    assert result == {"linked": 0, "skipped": 1}
+    assert db.query(models.ChannelLink).count() == 0
+
+
+def test_line_webhook_does_not_link_follow_without_patient_ref(db, messaging_key):
+    cfg = _config(db)
+    payload = {
+        "events": [{
+            "type": "follow",
+            "source": {"type": "user", "userId": "Uline123"},
+        }]
+    }
+
+    result = wh.handle_line_events(db, payload, config=cfg)
+
+    assert result == {"linked": 0, "skipped": 1}
+    assert db.query(models.ChannelLink).count() == 0
+
+
+def test_telegram_secret_verify_and_free_text_ref_does_not_link(db, messaging_key):
+    """SECURITY: secret-token verify works; a forgeable `/start patient:<id>` must
+    NOT create a link nor send a confirmation reply (linking is Mini-App-only)."""
+    cfg = _config(db)
+    http = FakeTelegramReplyHttp()
+    update = {
+        "update_id": 1,
+        "message": {
+            "message_id": 10,
+            "chat": {"id": 9001, "type": "private"},
+            "text": "/start patient:88",
+        },
+    }
+
+    assert wh.verify_telegram_secret(cfg, "telegram-secret") is True
+    assert wh.verify_telegram_secret(cfg, "wrong-secret") is False
+
+    result = wh.handle_telegram_update(db, update, config=cfg, http_client=http)
+
+    assert result == {"linked": 0, "skipped": 1}
+    assert db.query(models.ChannelLink).count() == 0
+    assert http.calls == []   # no "ผูกบัญชีแล้ว" confirmation for a forged ref
+
+
+def test_telegram_start_service_point_sends_checkin_button_without_linking(db, messaging_key):
+    cfg = _config(db)
+    http = FakeTelegramReplyHttp()
+    update = {
+        "update_id": 2,
+        "message": {
+            "message_id": 11,
+            "chat": {"id": 9002, "type": "private"},
+            "text": "/start sp_7",
+        },
+    }
+
+    result = wh.handle_telegram_update(
+        db,
+        update,
+        config=cfg,
+        http_client=http,
+        public_base_url="https://humnoi.example.com/",
+        subdomain="humnoi",
+    )
+
+    assert result == {"linked": 0, "skipped": 1, "action": "checkin_button"}
+    assert db.query(models.ChannelLink).count() == 0
+    assert len(http.calls) == 1
+    assert http.calls[0]["json"]["chat_id"] == 9002
+    assert http.calls[0]["json"]["reply_markup"] == {
+        "inline_keyboard": [[{
+            "text": "เปิดหน้าเช็คอิน",
+            "web_app": {
+                "url": "https://humnoi.example.com/queue/checkin/7?subdomain=humnoi",
+            },
+        }]],
+    }
+
+
+def test_extract_patient_ref_normalizes_phone_ref():
+    assert wh.extract_patient_ref("patient_ref=phone:%2B66812345678") == "phone:+66812345678"
+    assert wh.extract_patient_ref("สมชาย ใจดี") is None
+
+
+def test_validate_telegram_init_data_accepts_valid_payload(db, messaging_key):
+    cfg = _config(db, telegram_token="123456:telegram-token")
+    now = int(datetime.datetime(2026, 6, 17, tzinfo=datetime.timezone.utc).timestamp())
+    user = json.dumps({"id": 9001, "first_name": "Test"}, separators=(",", ":"))
+    init_data = _init_data("123456:telegram-token", {
+        "auth_date": str(now),
+        "query_id": "AAE",
+        "user": user,
+    })
+
+    data = wh.validate_telegram_init_data(cfg, init_data, now=now)
+
+    assert data["auth_date"] == str(now)
+    assert data["query_id"] == "AAE"
+    assert data["user"] == {"id": 9001, "first_name": "Test"}
+
+
+def test_validate_telegram_init_data_rejects_bad_hash_and_expired(db, messaging_key):
+    cfg = _config(db, telegram_token="123456:telegram-token")
+    now = int(datetime.datetime(2026, 6, 17, tzinfo=datetime.timezone.utc).timestamp())
+    valid = _init_data("123456:telegram-token", {
+        "auth_date": str(now),
+        "query_id": "AAE",
+    })
+
+    with pytest.raises(wh.InitDataValidationError, match="hash invalid"):
+        wh.validate_telegram_init_data(cfg, valid.replace("hash=", "hash=bad"), now=now)
+
+    expired = _init_data("123456:telegram-token", {
+        "auth_date": str(now - 301),
+        "query_id": "AAE",
+    })
+    with pytest.raises(wh.InitDataValidationError, match="expired"):
+        wh.validate_telegram_init_data(cfg, expired, now=now)


### PR DESCRIPTION
…cs quota + hardening

Phase 4 channel round + Phase 5.3 + review-round fixes. 144 tests passing.

Channels & identity:
- LINE (LIFF id-token verify), Telegram (initData HMAC), PWA (Web Push) linked only via the verified Mini App channel-auth flow; webhook_routes + messaging_identity/messaging_links; telegram provisioning + SaaS account pool
- no identity linking from forgeable free-text refs

Queue / notify:
- /queue/enter deep-link router consumes Telegram startapp + LINE liff.state and forwards to the right check-in page (same-origin guarded)
- async queue notifications carry the signed ticket URL so PWA push opens the ticket instead of "/"

Security / robustness:
- signed, tenant-bound ticket tokens replace the enumerable /queue/ticket/<id>
- per-IP Redis rate-limit on the public check-in (fail-open)
- _messaging_config() no-tenant guard: /queue/enter and /pwa/config no longer 500
- telegram pool: idempotent retry after an account is marked full

Analytics 5.3:
- live LINE push quota (remaining) on the analytics dashboard

Dev tooling:
- telegram_poller.py (long-poll for local http testing; webhook for deploy)
- line_rich_menu.py (4.4 rich menu setup)

Deps: pywebpush==2.3.0 (coexists with pinned cryptography==46.0.3).